### PR TITLE
Lower memory request to 512M.

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -78,7 +78,7 @@ jupyterhub:
 
   singleuser:
     memory:
-      guarantee: 1G
+      guarantee: 512M
       limit: 1G
     image:
       name: gcr.io/ucb-datahub-2018/primary-user-image


### PR DESCRIPTION
Limit remains 1G. This should help pack more users onto each node.