### PR TITLE
Fix package name for jupyter-matplotlib

### DIFF
--- a/deployments/datahub/image/Dockerfile
+++ b/deployments/datahub/image/Dockerfile
@@ -204,7 +204,7 @@ RUN jupyter serverextension enable  --sys-prefix --py nbzip && \
 RUN jupyter labextension install \
             @jupyterlab/hub-extension \
             @jupyter-widgets/jupyterlab-manager \
-            @jupyter-matplotlib \
+            jupyter-matplotlib \
             @jupyterlab/plotly-extension \
             @jupyterlab/geojson-extension
 


### PR DESCRIPTION
No @, which are only used for scoped npm packages.