### PR TITLE
Fix suffix notation for JupyterHub memory request

### DIFF
--- a/deployments/math124/config/common.yaml
+++ b/deployments/math124/config/common.yaml
@@ -9,7 +9,7 @@ jupyterhub:
 
   singleuser:
     memory:
-      guarantee: 256Mi
+      guarantee: 256M
       limit: 1G
     image:
       name: gcr.io/ucb-datahub-2018/math124-user-image


### PR DESCRIPTION
We should make it accept both values..