### PR TITLE
Set tiny request for EECS CPU resources

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -75,5 +75,7 @@ jupyterhub:
       # hopefully prevent users from stomping on users from other
       # hubs on the same nodes
       limit: 1
+      # Set tiny request to prevent k8s from setting limit == request
+      request: 0.01
     image:
       name: gcr.io/ucb-datahub-2018/eecs-user-image


### PR DESCRIPTION
otherwise it sets limit = request, and everyone gets
1 CPU guaranteed