### PR TITLE
Add jupyterlab retro to images

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -8,22 +8,21 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.2.0
+notebook==6.4.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
-setuptools>=56.0
-jupyterlab==3.0.14
+jupyterlab==3.0.16
+retrolab==0.2.1
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
-otter-grader==2.1.0
+otter-grader==2.1.7
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.


### PR DESCRIPTION
With luck, we can eventually replace the default notebook
interface with https://pypi.org/project/jupyterlab/

I also bump a bunch of other dependencies while I'm at it.
The setuptools pin is no longer required, so I've removed it.