### PR TITLE
Add PH250A Instructor and GSIs to admin privileges

### DIFF
--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -59,6 +59,18 @@ jupyterhub:
           - shaziakn
           - jiyunwen
           # List of other admin users
+          # PH250A & PHW250A Fall 2021 GSIs / Instructor
+          - smccoy
+          - krista_neumann
+          - lsheira
+          - julia.acker
+          - jessiiicamae
+          - natasha_harrison
+          - hcolbeth
+          - caroline.kurtz
+          - eric_stewart
+          - judytan     
+          - lkamil
 
   singleuser:
     extraAnnotations:


### PR DESCRIPTION
We will be using Datahub for our 2021 Fall class. Thank you!