### PR TITLE
Check whether custom profiles has keys.

### DIFF
--- a/images/fetch-course-emails/course-emails.py
+++ b/images/fetch-course-emails/course-emails.py
@@ -96,6 +96,9 @@ def read_profiles(values_file):
 	if 'profiles' not in values['custom']:
 		print("No 'custom.profiles' in values.yaml.")
 		return []
+	if not hasattr(values['custom']['profiles'], 'keys'):
+		print("'custom.profiles' is not a dictionary.")
+		return []
 
 	return list(values['custom']['profiles'].keys())
 


### PR DESCRIPTION
This prevents the script from failing if the configuration has an empty
`profiles` value rather than an empty dictionary ({}).