### PR TITLE
Specify TZ explicitly for RStudio

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -139,8 +139,12 @@ COPY rsession.conf /etc/rstudio/rsession.conf
 # the packages we install. Without this, RStudio doesn't see the packages
 # that R does.
 # Stolen from https://github.com/jupyterhub/repo2docker/blob/6a07a48b2df48168685bb0f993d2a12bd86e23bf/repo2docker/buildpacks/r.py
+# To try fight https://community.rstudio.com/t/timedatectl-had-status-1/72060,
+# which shows up sometimes when trying to install packages that want the TZ
+# timedatectl expects systemd running, which isn't true in our containers
 RUN sed -i -e '/^R_LIBS_USER=/s/^/#/' /etc/R/Renviron && \
-    echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron
+    echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron && \
+    echo "TZ=${TZ}"
 
 # Install R libraries as our user
 USER ${NB_USER}

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -144,7 +144,7 @@ COPY rsession.conf /etc/rstudio/rsession.conf
 # timedatectl expects systemd running, which isn't true in our containers
 RUN sed -i -e '/^R_LIBS_USER=/s/^/#/' /etc/R/Renviron && \
     echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron && \
-    echo "TZ=${TZ}"
+    echo "TZ=${TZ}" >> /etc/R/Renviron
 
 # Install R libraries as our user
 USER ${NB_USER}

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -268,12 +268,3 @@ RUN jupyter nbextension enable --py --sys-prefix qgrid
 
 
 EXPOSE 8888
-
-# Temporarily install new nbconvert version to fix pagination in PDF generation
-# This can't be in infra-requirements, since that seems to just install the
-# published versions of nbconvert from notebook. Adding this to the end of the
-# image so we can experiment with this faster.
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-RUN pip install --no-cache git+https://github.com/yuvipanda/nbconvert@888f39b9fe131f8af403a9396538996afbfd7aa2

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
 jupyter-resource-usage==0.5.1


### PR DESCRIPTION
RStudio doesn't load environment variables in the
container (grr), so we need to explicitly set them again.
Looks like something is intermittently trying to get the
current TZ by calling `timedatectl`, which is a systemd
thing. We don't run systemd in this container, so this
fails / provides a scary warning. A bit hard to reproduce,
but hopefully this will help?