### PR TITLE
Explicitly ask for traitlets > 5.0

### DIFF
--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -16,6 +16,7 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
+traitlets>=5.0 # Requirement for nbconvert, conflicts with something else?
 nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0


### PR DESCRIPTION
nbconvert wants a new one. So running any `jupyter`
commands fail with:

pkg_resources.ContextualVersionConflict: (traitlets 4.3.3, Requirement.parse('traitlets>=5.0'), {'nbconvert'})