### PR TITLE
Use repo2docker from pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,6 @@ orbs:
                 python3 -m venv venv
                 source venv/bin/activate
                 pip install --upgrade -r requirements.txt
-                # Install repo2docker master to fix offline-notebook and julia
-                # See https://github.com/berkeley-dsep-infra/datahub/pull/1937
-                # See https://github.com/jupyterhub/repo2docker/pull/975
-                pip install --upgrade git+https://github.com/jupyter/repo2docker.git@968cc43a9e238916b5032edbf84e309c8d4ff35e
                 echo 'export PATH="${HOME}/repo/venv/bin:$PATH"' >> ${BASH_ENV}
 
           - unless:

--- a/deployments/eecs/image/environment.yml
+++ b/deployments/eecs/image/environment.yml
@@ -3,10 +3,9 @@ channels:
 # For jupyter-desktop-server
 - manics
 
-dependencies:
 # Almost all libraries should be added in requirements.txt
 # Only libraries *not* available in PyPI should be here
-
+dependencies:
 - python=3.8.*
 
 # Visual Studio Code!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 hubploy==0.2
 pygithub
 chartpress
-
+jupyter-repo2docker>=2021.3.0
 myst-parser


### PR DESCRIPTION
Maybe the build error around nbconvert version conflicts
will go away if we use a newer version of repo2docker? The
PRs we were waiting to be released have been out for a
while