### PR TITLE
Revert rstudio 1.4 in ischool hub

### DIFF
--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -34,8 +34,6 @@ jupyterhub:
 
   singleuser:
     defaultUrl: /rstudio/auth-sign-in?appUrl=%2F
-    extraEnv:
-      RSESSION_PROXY_RSTUDIO_1_4: "1"
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool
     storage:

--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -33,7 +33,7 @@ jupyterhub:
           - dhughes  # https://github.com/berkeley-dsep-infra/datahub/issues/2462
 
   singleuser:
-    defaultUrl: /rstudio/auth-sign-in?appUrl=%2F
+    defaultUrl: /rstudio
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool
     storage:

--- a/deployments/ischool/image/Dockerfile
+++ b/deployments/ischool/image/Dockerfile
@@ -40,7 +40,9 @@ RUN apt-get update > /dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.4.1717-amd64.deb
+# 1.3.959 is latest version that works with jupyter-rsession-proxy
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/93#issuecomment-725874693
+ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.3.959-amd64.deb
 RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb


### PR DESCRIPTION
Reverts https://github.com/berkeley-dsep-infra/datahub/pull/2473,
https://github.com/berkeley-dsep-infra/datahub/pull/2474 and
https://github.com/berkeley-dsep-infra/datahub/pull/2475.

This will be a backwards incompatible change for nbgitpuller links,
so reverting until we can fix that.