### PR TITLE
Mount persistent home in /home/rstudio for PH & ISchool

### DIFF
--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -37,6 +37,10 @@ jupyterhub:
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool
     storage:
+      # Rocker based images have 'rstudio' as user $1000
+      # so let's stick to that, and use /home/${NB_USER}
+      # consistently.
+      homeMountPath: /home/rstudio
       type: static
       static:
         pvcName: home-nfs

--- a/deployments/publichealth/config/common.yaml
+++ b/deployments/publichealth/config/common.yaml
@@ -66,9 +66,14 @@ jupyterhub:
           - lkamil
   singleuser:
     defaultUrl: /rstudio
+
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool
     storage:
+      # Rocker based images have 'rstudio' as user $1000
+      # so let's stick to that, and use /home/${NB_USER}
+      # consistently.
+      homeMountPath: /home/rstudio
       type: static
       static:
         pvcName: home-nfs


### PR DESCRIPTION
These images are based off the R community maintained
Rocker images, and so the user id there is 'rstudio'. In keeping
with that, we put our home directory mount under /home/rstudio,
rather than /home/jovyan