### PR TITLE
Pin R to 4.0.5

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -79,20 +79,20 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Use newer version of R
-# Binary packages from packagemanager.rstudio.com work against this.
-# Base R from Focal is only 3.6.
+# Install R packages
+# Our pre-built R packages from rspm are built against system libs in focal
+# rstan takes forever to compile from source, and needs libnodejs
+# We don't want R 4.1 yet - the graphics protocol version it has is incompatible
+# with the version of RStudio we use. So we pin R to 4.0.5
+ENV R_VERSION=4.0.5-1.2004.0
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc/apt/sources.list.d/cran.list
-
-# Install R packages
 RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
-    r-base \
-    r-base-dev \
-    r-recommended \
-    r-cran-littler  > /dev/null
-
+    r-base=${R_VERSION} \
+    r-base-dev=${R_VERSION} \
+    r-recommended=${R_VERSION} \
+    r-cran-littler > /dev/null
 
 # Needed by RStudio
 RUN apt-get update -qq --yes && \

--- a/deployments/ischool/image/Dockerfile
+++ b/deployments/ischool/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:4.1.0
+FROM rocker/geospatial:4.0.5
 
 ENV NB_USER rstudio
 ENV NB_UID 1000

--- a/deployments/publichealth/image/Dockerfile
+++ b/deployments/publichealth/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:4.1.0
+FROM rocker/geospatial:4.0.5
 
 ENV NB_USER rstudio
 ENV NB_UID 1000


### PR DESCRIPTION
R 4.1 has a new graphics protocol that is not compatible with RStudio 1.3, and we
can't move to RStudio 1.4 year because jupyter-rsession-proxy doesn't support
it yet. So we pin to R 4.0.5 until we can use RStudio 1.4

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2488