### PR TITLE
Install *just* R from apt

### DIFF
--- a/deployments/biology/image/Dockerfile
+++ b/deployments/biology/image/Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
     r-base-core=${R_VERSION} \
     r-base-dev=${R_VERSION} \
+    r-cran-littler \
     libglpk-dev \
     libzmq5 \
     nodejs npm > /dev/null

--- a/deployments/biology/image/Dockerfile
+++ b/deployments/biology/image/Dockerfile
@@ -67,10 +67,8 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD5
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc/apt/sources.list.d/cran.list
 RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
-    r-base=${R_VERSION} \
+    r-base-core=${R_VERSION} \
     r-base-dev=${R_VERSION} \
-    r-recommended=${R_VERSION} \
-    r-cran-littler \
     libglpk-dev \
     libzmq5 \
     nodejs npm > /dev/null

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -90,7 +90,8 @@ RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc
 RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
     r-base-core=${R_VERSION} \
-    r-base-dev=${R_VERSION} > /dev/null
+    r-base-dev=${R_VERSION} \
+    r-cran-littler > /dev/null
 
 # Needed by RStudio
 RUN apt-get update -qq --yes && \

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -89,10 +89,8 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD5
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc/apt/sources.list.d/cran.list
 RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
-    r-base=${R_VERSION} \
-    r-base-dev=${R_VERSION} \
-    r-recommended=${R_VERSION} \
-    r-cran-littler > /dev/null
+    r-base-core=${R_VERSION} \
+    r-base-dev=${R_VERSION} > /dev/null
 
 # Needed by RStudio
 RUN apt-get update -qq --yes && \


### PR DESCRIPTION
Everything else comes from CRAN. Without this,
r-recommended was still pulling in newer R.