### PR TITLE
Collect data on which python modules are being used

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -124,6 +124,12 @@ jupyterhub:
         - ports:
             - port: 22
               protocol: TCP
+        - ports:
+            # statsd ports
+            - port: 9125
+              protocol: TCP
+            - port: 9125
+              protocol: UDP
   custom:
     # this should be migrated to custom.profiles when that works
     profiles:

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -32,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -90,8 +90,15 @@ jupyterhub:
       letsencrypt:
         contactEmail: yuvipanda@berkeley.edu
   singleuser:
+    extraFiles:
+      popularity-contest:
+        mountPath: /opt/conda/etc/ipython/startup/000-popularity-contest.py
+        stringData: |
+          import popularity_contest.reporter
     extraEnv:
       SHELL: /bin/bash
+      PYTHON_POPCONTEST_STATSD_HOST: 'support-prometheus-statsd-exporter.support'
+      PYTHON_POPCONTEST_STATSD_PORT: '9125'
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     extraAnnotations:
       prometheus.io/scrape: "false"
@@ -117,6 +124,12 @@ jupyterhub:
             # Allow FTP access https://github.com/berkeley-dsep-infra/datahub/issues/1789
             - port: 21
               protocol: TCP
+        - ports:
+            # statsd ports
+            - port: 9125
+              protocol: TCP
+            - port: 9125
+              protocol: UDP
       # Allow ingress from promethetheus scraper in support namespace
       # This lets us get notebook metrics!
       ingress:
@@ -320,3 +333,10 @@ jupyterhub:
             'allowPrivilegeEscalation': False
           }
         }
+      07-popularity-contest: |
+        # Emit metrics for which python packages are being imported
+        import os
+        pod_namespace = os.environ['POD_NAMESPACE']
+        c.KubeSpawner.environment.update({
+          'PYTHON_POPCONTEST_STATSD_PREFIX': f'python_popcon.hub.{pod_namespace}.imported_package'
+        })

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -16,7 +16,6 @@ notebook==6.4.0
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
 jupyterlab==3.0.16
-traitlets>=5.0 # Requirement for nbconvert, conflicts with something else?
 nbconvert==6.1.0
 retrolab==0.2.1
 nbgitpuller==0.10.0
@@ -33,3 +32,6 @@ git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
 jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.1.1

--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,4 +1,7 @@
 dependencies:
+ - name: prometheus-statsd-exporter
+   version: 0.3.1
+   repository: https://prometheus-community.github.io/helm-charts
  - name: prometheus
    version: 11.16.9
    repository: https://prometheus-community.github.io/helm-charts

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -123,3 +123,18 @@ grafana:
           access: proxy
           isDefault: true
           editable: false
+
+prometheus-statsd-exporter:
+  service:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9102"
+
+  statsd:
+    mappingConfig: |-
+      mappings:
+      - match: "python_popcon.hub.*.imported_package.*"
+        name: "python_popcon_imported_package"
+        labels:
+          hub: "$1"
+          package: "$2"


### PR DESCRIPTION
https://github.com/yuvipanda/python-popcontest can
be used to put metrics into prometheus about how often python
packages are being used - this will help us clean up unused
libraries.

We want to collect aggregated information about which
packages are being used, but we do not want to identify
individual users. statsd is perfect for it - we can push
data to it when the process exits, and it globally
aggregates our metrics.
    
We parse out useful labels from statsd metric names,
so we can run useful queries over it in prometheus

See https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994 for more information.