### PR TITLE
Use namespace instead of hub as prometheus label

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -136,5 +136,5 @@ prometheus-statsd-exporter:
       - match: "python_popcon.hub.*.imported_package.*"
         name: "python_popcon_imported_package"
         labels:
-          hub: "$1"
+          namespace: "$1"
           package: "$2"


### PR DESCRIPTION
Consistent with other metrics we get from kubernetes
itself