### PR TITLE
Add chardet explicitly as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pygithub
 chartpress
 jupyter-repo2docker>=2021.3.0
 myst-parser
+chardet


### PR DESCRIPTION
repo2docker seems to need it, and whatever transient
dependency provided it seems to no longer provide it