### PR TITLE
Move datahub to python 3.9

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -238,14 +238,6 @@ RUN pip install --no-cache numpy==1.19.5 cython==0.29.21
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
-# Hack to get PyMC3 working for Data 102 & Astro 128/256
-# These are the same versions as in requirements.txt, but
-# the import fails unless you uninstall and reinstall
-# See https://github.com/berkeley-dsep-infra/datahub/issues/2207
-RUN pip uninstall Theano Theano-PyMC pymc3 -y
-RUN pip install --no-cache 'Theano==1.0.5'
-RUN pip install --no-cache 'pymc3==3.11.0'
-
 # Set up nbpdf dependencies
 ENV PYPPETEER_HOME ${CONDA_DIR}
 RUN pyppeteer-install

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -1,4 +1,4 @@
 dependencies:
 - nodejs==15.*
 - pip==20.2.*
-- python==3.8.*
+- python==3.9.*

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -2,3 +2,6 @@ dependencies:
 - nodejs==15.*
 - pip==20.2.*
 - python==3.9.*
+
+# pymc3 needs this
+- mkl-service==2.4.*

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -85,9 +85,6 @@ Pint==0.17
 gspread-pandas==2.3.0
 gspread==4.0.1
 
-# psych101d; fall 2019; cfrye
-Theano==1.0.5
-
 # eps 109; fall 2019
 ffmpeg-python==0.2.0
 # see https://github.com/berkeley-dsep-infra/datahub/issues/1796

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -21,7 +21,6 @@ mplleaflet==0.0.5
 geopandas==0.9.0
 geopy==2.2.0
 pysal==2.5.0
-https://github.com/matplotlib/basemap/archive/v1.2.2rel.tar.gz
 rtree==0.9.7
 netCDF4==1.5.7
 #

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -1,16 +1,16 @@
 # data8; foundation
 datascience==0.17.0
-matplotlib==3.3.3
-ipympl==0.6.2
-pandas==1.2.0
-scipy==1.6.0
-statsmodels==0.11.1
+matplotlib==3.4.3
+ipympl==0.7.0
+pandas==1.3.2
+scipy==1.7.1
+statsmodels==0.12.2
 okpy==1.18.1
-folium==0.11
+folium==0.12.1
 #
 # r
-jupyter-server-proxy==3.0.2
-jupyter-rsession-proxy==1.2
+jupyter-server-proxy==3.1.0
+jupyter-rsession-proxy==1.4
 jupyter-shiny-proxy==1.1
 #
 # cogsci88;
@@ -19,72 +19,72 @@ ggplot==0.11.5
 # geog88; spring 2018
 mplleaflet==0.0.5
 geopandas==0.9.0
-geopy==2.1.0
-pysal==2.3.0
+geopy==2.2.0
+pysal==2.5.0
 https://github.com/matplotlib/basemap/archive/v1.2.2rel.tar.gz
 rtree==0.9.7
-netCDF4==1.5.5.1
+netCDF4==1.5.7
 #
 # cogsci131; spring 2018
 nose==1.3.7
 #
 # modules
-scikit-learn==0.24.0
-seaborn==0.11.1
-bokeh==2.2.3
-decorator==4.4.2
-networkx==2.5
+scikit-learn==0.24.2
+seaborn==0.11.2
+bokeh==2.3.3
+decorator==5.0.9
+networkx==2.6.2
 # pygame==1.9.6
-nltk==3.5
+nltk==3.6.2
 beautifulsoup4==4.9.3
-spacy==2.3.5
+spacy==3.1.1
 qgrid==1.3.1
 nb2pdf==0.6.2
 #
 # ls 88-3; neuro
-lxml==4.6.2
-tqdm==4.56.0
-mne==0.22.0
+lxml==4.6.3
+tqdm==4.62.1
+mne==0.23.0
 nibabel==3.2.1
-h5py==3.1.0
-pillow==8.1.0
-numexpr==2.7.2
-openpyxl==3.0.6
-nilearn==0.7.0
+h5py==3.3.0
+pillow==8.3.1
+numexpr==2.7.3
+openpyxl==3.0.7
+nilearn==0.8.0
 
 # phys 151;
-emcee==3.0.2
-daft==0.1.0
-corner==2.1.0
+emcee==3.1.0
+daft==0.1.2
+corner==2.2.1
 #
 # ce88;
-pymdptoolbox==4.0b3
+pymdptoolbox==4.0-b3
 #
 # data-x; DL
 tensorflow==2.6.0
-scikit-image==0.18.1
+scikit-image==0.18.2
 tables==3.6.1
-opencv-python==4.5.1.48
+opencv-python==4.5.3.56
 
 # astr 128/256; spring 2021
-astroquery==0.4.1
-astropy==4.2
-dustmaps==1.0.6
-george==0.3.1
-exoplanet==0.4.3
-torch==1.7.1
-torchvision==0.8.2
+astroquery==0.4.3
+astropy==4.3.1
+dustmaps==1.0.9
+george==0.4.0
+exoplanet==0.5.1
+torch==1.9.0
+torchvision==0.10.0
 pyvo==1.1
-joblib==1.0.0
-theano-pymc==1.1.0
-pymc3==3.11.0
+joblib==1.0.1
+theano-pymc==1.1.2
+pymc3==3.11.2
 
 # eep 153; spring 2019
-requests==2.25.1
-Pint==0.16.1
+requests==2.26.0
+Pint==0.17
 # Google spreadsheets, Eric Van Dusen / Keeley Takimoto / Modules
-gspread-pandas==2.2.3
-gspread==3.6.0
+gspread-pandas==2.3.0
+gspread==4.0.1
 
 # psych101d; fall 2019; cfrye
 Theano==1.0.5
@@ -92,14 +92,14 @@ Theano==1.0.5
 # eps 109; fall 2019
 ffmpeg-python==0.2.0
 # see https://github.com/berkeley-dsep-infra/datahub/issues/1796
-Cartopy==0.18.0 --no-binary Cartopy
+Cartopy==0.19.0.post1 --no-binary Cartopy
 
 # data 88e; spring 2021
-plotly==4.14.3
-mpmath==1.1.0
+plotly==5.2.1
+mpmath==1.2.1
 # sympy==1.6.2
 chart-studio==1.1.0
-csaps==1.0.3
+csaps==1.0.4
 nbforms==0.5.1
 gmaps==0.9.0
 
@@ -107,52 +107,52 @@ gmaps==0.9.0
 wordcloud==1.8.1
 
 # issue #929, SW 282 - fall 2019
-pyreadstat==1.0.8
+pyreadstat==1.1.2
 
 # issue 954, EPS24 - fall 2019
-xarray==0.16.2
+xarray==0.19.0
 
 # issue 1001, Physics 188/288 - fall 2019
-umap-learn==0.5
-hdbscan==0.8.26
+umap-learn==0.5.1
+hdbscan==0.8.27
 
 # espm 125/bio 105; fall 2019
 # see https://github.com/berkeley-dsep-infra/datahub/issues/1796
 shapely==1.7.1 --no-binary shapely
 pyvcf==0.6.8
-bitarray==1.6.1
-nlmpy==1.0.0
+bitarray==2.3.0
+nlmpy==1.0.1
 
 # physics 188/288 fall, 2019
-getdist==1.1.2
+getdist==1.3.1
 tensorflow-hub==0.12.0
 tensorflow-probability==0.13.0
 
 # mcb 163l, fall 2019
-pydot==1.4.1
-allensdk==2.4.1
+pydot==1.4.2
+allensdk==2.12.2
 
 # cs16A/B, spring 2020
-lcapy==0.77
+lcapy==0.96
 
 # EPS 256, https://github.com/berkeley-dsep-infra/datahub/issues/1775
 obspy==1.2.2
 
 # ds198 mch infodemiology, fall 2020/spring 2021
 # google apis
-google-api-python-client==1.12.8
-google-auth-httplib2==0.0.4
-google-auth-oauthlib==0.4.1
+google-api-python-client==2.15.0
+google-auth-httplib2==0.1.0
+google-auth-oauthlib==0.4.5
 google==3.0.0
 
 # issue 1847; LS 22 spring 2021
-graphviz==0.16
+graphviz==0.17
 
 # issue #1903, data h195A fall 2020
 habanero==0.7.4
 
 # https://github.com/berkeley-dsep-infra/datahub/issues/1981
-ipycanvas==0.8.1
+ipycanvas==0.9.0
 
 # Issue #1222, for PH 142 - Spring 2020
 PyPDF2==1.26.0
@@ -168,51 +168,51 @@ altair==4.1.0
 
 # data100 tools to access things
 tweepy==3.10.0
-pytz==2020.5
-psycopg2==2.8.6
+pytz==2021.1
+psycopg2==2.9.1
 
 # data100 teaching
 jassign==0.0.7
 dsassign==0.0.8
 
 # data102
-dask==2020.12.0
-distributed==2020.12.0
+dask==2021.8.0
+distributed==2021.8.0
 keras-applications==1.0.8
 keras-preprocessing==1.1.2
-keras==2.4.3
+keras==2.6.0
 keras-vis==0.4.1
 plotly-express==0.4.1
 cytoolz==0.11.0
-pyro-ppl==1.5.2
+pyro-ppl==1.7.0
 lime==0.2.0.1
 shap==0.39.0
 
 # prob140 2021 Spring
 prob140==0.4.1.5
-sympy==1.7.1
+sympy==1.8
 
 # stat159 2021 Spring
-cryptorandom==0.2
+cryptorandom==0.3
 git+https://github.com/statlab/permute@v0.1.a5
-pycodestyle==2.6.0
+pycodestyle==2.7.0
 pep257==0.7.0
 
 # cs194 2021 Spring
 ipython-sql==0.4.0
-pgspecial==1.11.10
-pymongo==3.11.3
-dbt==0.19.1
+pgspecial==1.13.0
+pymongo==3.12.0
+dbt==0.20.1
 
 # ESPM 167 - https://github.com/berkeley-dsep-infra/datahub/issues/2278
 contextily==1.1.0
 
 # INDENG 142 Spring 2021 (future semesters as well) - https://github.com/berkeley-dsep-infra/datahub/issues/2314
-fancyimpute==0.5.5
+fancyimpute==0.6.0
 
 # JupyterLab pypi extensions
 jupyterlab-geojson==3.1.2
 
 # LBL summer research internship in materials informatics. Jupyter Book curriculum at https://enze-chen.github.io/mi-book/
-pymatgen==2020.10.20
-matminer==0.6.5
+pymatgen==2022.0.11
+matminer==0.7.4


### PR DESCRIPTION
- Bumps *all* python packages to latest version,
   both for 3.9 compatibility & as a pre-semester
   bump

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2533