### PR TITLE
Adding fall 2021 admins for Data 8 + Template for feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/featurerequest.md
+++ b/.github/ISSUE_TEMPLATE/featurerequest.md
@@ -1,0 +1,27 @@
+# Template Credits: 2I2C
+
+# Summary
+
+<!-- What is the context needed to understand this enhancement -->
+
+# User Stories
+
+<!-- Who is this enhancement for? What need does it address? -->
+
+- As a `<type of user>` I want to `<do something not yet possible>` so that `<I get some kind of value>`.
+- ...
+
+# Acceptance criteria
+
+<!-- When will we know that this enhancement is complete? -->
+
+- Given `<some scenario>`, when `<some action is taken>`, then `<a specific result happens>`.
+
+# Important information
+
+<!-- A bulleted list of important information or links -->
+
+# Tasks to complete
+
+<!-- What tasks are needed to make this enhancement? -->
+

--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -33,52 +33,103 @@ jupyterhub:
           - yuvipanda
           - felder
           - balajialwar
-          # Summmer 2021 Admins, from Yanay
-          - yanayrosen
-          - katherinetsai
-          - oscarb
-          - kylek
-          - jeshoung
-          - takaokakegawa
-          - wendykimm
+          # Fall 2021 Admins, from Meghan Wang  
+          - nellepersson
+          - meghanwang
+          - melissarwong
+          - sdjajadi
+          - carlosortiz
           - ritawang
-          - o.chang
-          - jacquelinekyu
+          - sunnyshen
+          - nicolepark
+          - joyceezheng
+          - willfurtado
+          - marmis
+          - nhanafi
+          - aarushi.k
+          - alicechen295
           - anna_zhao
-          - meiji193
-          - gprasann
-          - seanwei2001
-          - xinyueyou
-          - noah.s.tran
-          - lingjunguo
-          - jaqian
-          - kinsey.long
-          - ryanchien04
-          - stephaniex
-          - devin.sze
-          - efliu
-          - sarah.zha
-          - ellenkwok882
-          - ralui
-          - nataliegomas
-          - kanchoo
-          - stella1001wang
-          - vkarukonda
-          - pverde1
-          - lillianweng
-          - vpadma
-          - markcheunggg
-          - eunicechoi
-          - gracealtree
-          - rgoel777
-          - joannayoo
-          - graceyi89
-          - vivrd
-          - haru.yamamoto
-          - itisashwin
-          - cayanan.joshua
+          - ashika-raghavan
           - ciara.acosta
+          - efliu
+          - ellenkwok882
+          - eshadgoo972
+          - lingjunguo
+          - gracealtree
+          - graceyi89
+          - ichiachen1
+          - joshgreenberg
+          - kanchoo
+          - sjmoon21
+          - michellelou
+          - nickha
+          - o.chang
+          - oscarb
+          - vpadma
+          - ralui
+          - raymondwang
+          - rhu01
+          - selenalu
+          - shayan.ghosh
+          - stephaniex
+          - takaokakegawa
+          - jvarun
+          - wendykimm
+          - yuqiye
+          - anujalohia
+          - devarshdhanuka
+          - eshaansoman
+          - jacquelinekyu
+          - laeticiayang
+          - sydniezanone
+          - tongshen
+          - angelineyang
+          - atticus.ginsborg
+          - audreyim
+          - auroraxzeng
+          - csun457
+          - devin.sze
+          - eunicechoi
+          - haru.yamamoto
+          - jaqian
+          - joannayoo
+          - cayanan.joshua
+          - kaitlynphan
+          - karen.li
+          - katherine0806
+          - kinsey.long
+          - lillianweng
+          - mattyshen
+          - mirasharma
+          - nikaash.maheshwari
+          - noah.s.tran
+          - owensleigh
+          - Pverde1
+          - gprasann
+          - rithviksunku
+          - ryanhuntley23
+          - sahilthakur
+          - seanwei2001
+          - sofiakwee
+          - sonyak
+          - sonyashankar
+          - willchp
+          - zaidmaayah
+          - dianaqing
+          - elleanor.wong
+          - geli2001
+          - jweichert
+          - markcheunggg
+          - mlucas
+          - oswaldo1603
+          - rimikabanerjee
+          - rishabh297
+          - sabrinakma
           - sarafang
+          - tanyasjain
+          - umutuygur
+          - yiyan.hao
+
           # List of other admin users
 
   singleuser:


### PR DESCRIPTION
Objectives for commit #1: #2560 

- I wanted to add one more GitHub template for user enhancement (i.e., new feature requests by users)
- I wanted to know the steps required to push things (mainly documentation) to production via git and thought this would be a great learning opportunity! 

Objectives for commit #2: #2560 

- As per the request by Data 8 team, Added new admins for fall 2021
- Removed the summer 2021 Data 8 admins