### PR TITLE
Pin jupyter-client<7.0

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -9,6 +9,8 @@
 
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.3
+# Seems to cause a version conflict with jupyter-server-proxy
+jupyter-client<7.0
 jupyterlab==3.1.4
 nbconvert==6.1.0
 retrolab==0.2.2


### PR DESCRIPTION
7.0, released today, seems to have a version conflict
on nest-asyncio with jupyter-server-proxy:

[W 2021-08-20 11:22:41.520 SingleUserNotebookApp notebookapp:2034] Error loading server extension jupyter_server_proxy
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.9/site-packages/notebook/notebookapp.py", line 2030, in init_server_extensions
        func(self)
      File "/opt/conda/lib/python3.9/site-packages/jupyter_server_proxy/__init__.py", line 27, in _load_jupyter_server_extension
        server_processes += get_entrypoint_server_processes()
      File "/opt/conda/lib/python3.9/site-packages/jupyter_server_proxy/config.py", line 81, in get_entrypoint_server_processes
        make_server_process(entry_point.name, entry_point.load()())
      File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 2471, in load
        self.require(*args, **kwargs)
      File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 2494, in require
        items = working_set.resolve(reqs, env, installer, extras=self.extras)
      File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 790, in resolve
        raise VersionConflict(dist, req).with_context(dependent_req)
    pkg_resources.ContextualVersionConflict: (nest-asyncio 1.2.0 (/opt/conda/lib/python3.9/site-packages), Requirement.parse('nest-asyncio>=1.5'), {'jupyter-client'})

This pin should help contain the damage while we investigate