### PR TITLE
Fix compiler packages for eecs

### DIFF
--- a/deployments/eecs/image/environment.yml
+++ b/deployments/eecs/image/environment.yml
@@ -15,13 +15,14 @@ dependencies:
 
 # https://github.com/berkeley-dsep-infra/datahub/issues/2535
 # gcc, gdb, etc are newer in conda-forge than in apt, esp with Ubuntu focal
-- gcc_linux-64==11.1
-- gxx_linux-64==11.1
-- gfortran_linux-64==11.1
+- c-compiler==1.2.0
+- cxx-compiler==1.2.0
+- fortran-compiler==1.2.0
 - gdb==10.2
 - libopenblas==0.3.17
 - liblapack==3.9.0
 - armadillo==9.900.5
+- gperf==3.1
 # CS 16A
 # From https://github.com/berkeley-dsep-infra/datahub/issues/1363#issuecomment-598916469
 - numpy==1.21.2


### PR DESCRIPTION
Couldn't find any of these on PATH or elsewhere, so
let's try the meta packages. We can't specificy or see
direct gcc / gfortran versions here, but that's probably
ok.

Also install gperf since the instructor might want that