### PR TITLE
Put data8 in its own pool

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -133,7 +133,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: delta-pool
     storage:
       type: static
       static:

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -20,7 +20,7 @@ nodePools:
     resources:
       requests:
         memory: 46786Mi
-    nodes: 3
+    nodes: 2
   beta:
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
@@ -35,3 +35,10 @@ nodePools:
       requests:
         memory: 46786Mi
     nodes: 2
+  delta:
+    nodeSelector:
+      hub.jupyter.org/pool-name: delta-pool
+    resources:
+      requests:
+        memory: 46786Mi
+    nodes: 3


### PR DESCRIPTION
The alpha-pool has datahub in it, with its huge image. New
node spinup takes up extra time in the alpha pool, causing delays
in how long it takes data8 spikes to be handled. With a special
pool just for data8, we can reduce this spin-up time by only keeping
the data8 image on it.

The data8 pool also has SSD disks for faster image pulls - we can
reduce that later if necessary, but I think this should help with
image pull speeds.