### PR TITLE
Move r, data102 & prob140 to alpha pool

### DIFF
--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -40,7 +40,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -40,7 +40,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -65,7 +65,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:


### PR DESCRIPTION
datahub's overall usage numbers will go down as data8
has its own hub now. These 3 hubs just use the datahub
image, so we can put them all in alpha pool. This should
also help us reduce node placeholders.