### PR TITLE
Reduce node placeholders

### DIFF
--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -20,7 +20,7 @@ nodePools:
     resources:
       requests:
         memory: 46786Mi
-    nodes: 2
+    nodes: 1
   beta:
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
@@ -34,11 +34,11 @@ nodePools:
     resources:
       requests:
         memory: 46786Mi
-    nodes: 2
+    nodes: 1
   delta:
     nodeSelector:
       hub.jupyter.org/pool-name: delta-pool
     resources:
       requests:
         memory: 46786Mi
-    nodes: 3
+    nodes: 2


### PR DESCRIPTION
- data8 is in its own pool, with ssd disks. This should let us
  reduce node placeholders on alpha-pool and delta-pool.
- R, data102 and prob140 hubs are now in alpha-pool, so we can
  reduce the placeholders on gamma pool