### PR TITLE
Move data100 to alpha pool

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -59,7 +59,7 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -27,7 +27,7 @@ nodePools:
     resources:
       requests:
         memory: 46786Mi
-    nodes: 1
+    nodes: 0
   gamma:
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool


### PR DESCRIPTION
- It shares same image with datahub, so we can use the same
  pool.
- Earlier, data8 and data100 together caused scaling issues
  with new nodes not being able to come up fast enough. However,
  now that data8 has its own node pool, we can collapse datahub
  and data100 pools