### PR TITLE
Disable user scheduler for everything except data8x

### DIFF
--- a/deployments/data8x/config/common.yaml
+++ b/deployments/data8x/config/common.yaml
@@ -5,6 +5,9 @@ nfsPVC:
     shareName: export/data8xhomes-2020-08-31
 
 jupyterhub:
+  scheduling:
+    userScheduler:
+      enabled: true
   cull:
     # For some reason, hub users don't cull properly
     # Empty abandoned sessions stay on for days

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -20,7 +20,7 @@ jupyterhub:
       defaultPriority: 0
       userPlaceholderPriority: -10
     userScheduler:
-      enabled: true
+      enabled: false
       resources:
         requests:
           # FIXME: Just unset this?


### PR DESCRIPTION
Trying out the optimize-utilization autoscaler profile
in
https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler#autoscaling_profiles,
which comes with its own scheduler. Hopefully it can replicate the
behavior we get with user-scheduler, and we can reduce the amount
of resources we spend on core nodes. More importantly, this will
reduce race conditions between the default scheduler (used for the
node placeholders) and the user scheduler (used for pods). It was
causing 'node does not have enough memory' after the pod was
assigned to the node, so those nodes then just get stuck in limbo
forever.