### PR TITLE
Adding @cs.berkeley.edu suffix for Data8 admin

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -33,7 +33,7 @@ jupyterhub:
           - felder
           - balajialwar
           # Fall 2021 Admins, from Meghan Wang  
-          - daw
+          - daw@cs.berkeley.edu
           - nellepersson
           - meghanwang
           - melissarwong


### PR DESCRIPTION
Despite this [PR](https://github.com/berkeley-dsep-infra/datahub/commit/7ff6aa9867d8b77cc14b7e13e830f4f78627b838), I found that the user did not get added as an admin in Data 8 hub's staging server. So looked at the previous version of YAML file and figured that for those with @cs.berkeley.edu, their entire email id got added. 
