### PR TITLE
Increase concurrent spawn limit

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -115,6 +115,8 @@ jupyterhub:
             - port: 9125
               protocol: UDP
   hub:
+    # The default of 64 is way too low for us
+    concurrentSpawnLimit: 200
     config:
       Pagination:
         # Disable pagination completely, since there's no search functionality yet


### PR DESCRIPTION
64 is way too low for students to follow along the demo
during the lectures.