### PR TITLE
Bring up 6 spare nodes for data8

### DIFF
--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -41,4 +41,4 @@ nodePools:
     resources:
       requests:
         memory: 46786Mi
-    nodes: 2
+    nodes: 6


### PR DESCRIPTION
Working on a way to bring this up and down automatically for classes. But until
then, let's raise it manually to see if user pods do in fact displace all the placeholder
pods (or just one of them)