### PR TITLE
Allow gcal overrides for reducing node count

### DIFF
--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -74,7 +74,7 @@ def main():
 
         # Generate deployment config based on our config
         for pool_name, pool_config in config["nodePools"].items():
-            replica_count = max(pool_config["replicas"], replica_count_overrides.get(pool_name, 0))
+            replica_count = replica_count_overrides.get(pool_name, pool_config['replicas'])
             deployment = make_deployment(
                 pool_name,
                 placeholder_template,

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-n4387.h7280fdf7
+version: 0.0.1-n4388.h9cd876ff
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: gcr.io/ucb-datahub-2018/node-placeholder-scaler
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.1-n4387.h7280fdf7"
+  tag: "0.0.1-n4388.h9cd876ff"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Before this, calendar can only increase node count -
never decrease it. That makes it difficult to do conditional
night time reductions.