### PR TITLE
Move everything except data8 to alpha-pool

### DIFF
--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -39,7 +39,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/dlab/config/common.yaml
+++ b/deployments/dlab/config/common.yaml
@@ -33,7 +33,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -63,7 +63,7 @@ jupyterhub:
       DISPLAY: ":1.0"
     defaultUrl: "/lab"
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/highschool/config/common.yaml
+++ b/deployments/highschool/config/common.yaml
@@ -36,7 +36,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -48,7 +48,7 @@ jupyterhub:
   singleuser:
     defaultUrl: /rstudio
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       # Rocker based images have 'rstudio' as user $1000
       # so let's stick to that, and use /home/${NB_USER}

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -31,7 +31,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -86,7 +86,7 @@ nodePools:
     resources:
       requests:
         memory: 46786Mi
-    replicas: 1
+    replicas: 0
   delta:
     nodeSelector:
       hub.jupyter.org/pool-name: delta-pool


### PR DESCRIPTION
With the dynamic node placeholder scaler, we can automatically
increase the size of the cluster just before big classes. The
gamma node pool was helpful in rapid scale up, as the node pools
can be scaled independently, and not all images needed to be pulled
into all the nodes. However, two node pools lead to lower utilization
when some pods are spread out across the nodes in the node pool - we
end up with 6 nodes where we could have 3.

The new alpha node pool has SSD disks, and hopefully can come up
fast enough (when used with the placeholder) for all hubs except
data8.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2672