### PR TITLE
Pin ottr to 0.1 on publichealth

### DIFF
--- a/deployments/publichealth/image/r-packages/ph-142.r
+++ b/deployments/publichealth/image/r-packages/ph-142.r
@@ -23,9 +23,9 @@ class_libs = c(
   "googlesheets4", "0.2.0"
 )
 
-# https://github.com/berkeley-dsep-infra/datahub/issues/2483
 print("Installing ottr...")
-devtools::install_github('ucbds-infra/ottr', ref='1.1.1', upgrade_dependencies=FALSE, quiet=FALSE)
+# Pinned to this version so we do not break assignments
+devtools::install_github('ucbds-infra/ottr', ref='0.1.0', upgrade_dependencies=FALSE, quiet=FALSE)
 
 class_libs_install_version(class_name, class_libs)
 


### PR DESCRIPTION
ChandlerB tells me that ph142 relies on features in 0.1 and those
break when we move to 1.0. Let's pin this until a solution can
be reached.