### PR TITLE
Provide shared directory space for biology hub

### DIFF
--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -37,6 +37,12 @@ jupyterhub:
           # List of other admin users
           - psudmant
 
+  custom:
+    admin:
+      extraVolumeMounts:
+        - name: home
+          mountPath: /home/jovyan/shared-readwrite
+          subPath: _shared
   singleuser:
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool
@@ -45,6 +51,11 @@ jupyterhub:
       static:
         pvcName: home-nfs
         subPath: "{username}"
+      extraVolumeMounts:
+        - name: home
+          mountPath: /home/jovyan/shared
+          subPath: _shared
+          readOnly: true
     memory:
       guarantee: 2056M
       limit: 4G


### PR DESCRIPTION
Admins get a `shared-readwrite` directory that they can
write to. This is visible to everyone else as `shared` readonly
directory. Can be used to share large datasets with users.