### PR TITLE
Explicitly specify node-placeholder version

### DIFF
--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-n4388.h9cd876ff
+version: 0.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/support/Chart.yaml
+++ b/support/Chart.yaml
@@ -20,4 +20,5 @@ dependencies:
    version: 3.23.0
    repository: https://kubernetes.github.io/ingress-nginx
  - name: node-placeholder
+   version: 0.0.1
    repository: file://../node-placeholder


### PR DESCRIPTION
Maybe this will help with

Error: dependency "node-placeholder" has an invalid version/constraint format: improper constraint: