### PR TITLE
Move non-datahub image hubs to beta pool

### DIFF
--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -45,7 +45,7 @@ jupyterhub:
           subPath: _shared
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: beta-pool
     storage:
       type: static
       static:

--- a/deployments/dlab/config/common.yaml
+++ b/deployments/dlab/config/common.yaml
@@ -33,7 +33,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: beta-pool
     storage:
       type: static
       static:

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -63,7 +63,7 @@ jupyterhub:
       DISPLAY: ":1.0"
     defaultUrl: "/lab"
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: beta-pool
     storage:
       type: static
       static:

--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -48,7 +48,7 @@ jupyterhub:
   singleuser:
     defaultUrl: /rstudio
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: beta-pool
     storage:
       # Rocker based images have 'rstudio' as user $1000
       # so let's stick to that, and use /home/${NB_USER}

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -31,7 +31,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: beta-pool
     storage:
       type: static
       static:

--- a/deployments/publichealth/config/common.yaml
+++ b/deployments/publichealth/config/common.yaml
@@ -88,7 +88,7 @@ jupyterhub:
     defaultUrl: /rstudio
 
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: beta-pool
     storage:
       # Rocker based images have 'rstudio' as user $1000
       # so let's stick to that, and use /home/${NB_USER}


### PR DESCRIPTION
I want the alpha pool to *only* have the big datahub image,
and not all the images the individual hubs use. This should
hopefully temporarily help with spin-up time for the alpha pool
for now, as we address the underlying issue.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2733

I've also created a new beta pool, matching the other pools.
Particularly, they have a 200G SSD disk (rather than a balanced
disk) now.