### PR TITLE
Add texlive-lang-chinese to the data8 hub

### DIFF
--- a/deployments/data8/image/Dockerfile
+++ b/deployments/data8/image/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update > /dev/null && \
             pandoc \
             texlive-xetex \
             texlive-fonts-recommended \
+            # provides FandolSong-Regular.otf for issue #2714
+            texlive-lang-chinese \
             texlive-plain-generic > /dev/null
 
 # Install packages needed by notebook-as-pdf


### PR DESCRIPTION
Same fix from #2715 applied to the Data 8 Hub image.