### PR TITLE
Scrape HTTP request metrics from nginx

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -34,6 +34,11 @@ ingress-nginx:
         memory: 384Mi
     service:
       loadBalancerIP: 34.69.164.86
+    metrics:
+      enabled: true
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "10254"
     podLabels:
       hub.jupyter.org/network-access-proxy-http: 'true'
 


### PR DESCRIPTION
This gets metrics about requests and response codes
from nginx into prometheus, so we can look for 5xx and
4xx errors from it.

Note that datahub.berkeley.edu does *not* go through this,
but everything else. https://github.com/berkeley-dsep-infra/datahub/issues/2167
tracks that.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2693