### PR TITLE
Bump Grafana version

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
    version: 11.16.9
    repository: https://prometheus-community.github.io/helm-charts
  - name: grafana
-   version: 6.2.1
+   version: 6.16.12
    repository: https://grafana.github.io/helm-charts
  - name: cert-manager
    version: v1.1.0


### PR DESCRIPTION
Bumps us from 7.x to 8.x, for newer features and (hopefully)
better support for pagerduty - I couldn't get the pagerduty
alert notification to work with v2 API keys.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2693