### PR TITLE
Revert "Bump cartopy version"

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -48,6 +48,11 @@ RUN apt-get update > /dev/null && \
     apt-get -qq install --yes \
             # for LS88-5 and modules basemap
             libspatialindex-dev \
+            # for cartopy
+            libgeos-dev \
+            libproj-dev \
+            proj-data \
+            proj-bin \
             # For L&S22
             graphviz \
             # for phys 151
@@ -100,7 +105,7 @@ RUN apt-get update -qq --yes && \
         libapparmor1 \
         lsb-release \
         libclang-dev  > /dev/null
-
+            
 # apt packages needed for R packages
 RUN apt update --yes > /dev/null && \
     apt install --no-install-recommends --yes \
@@ -110,6 +115,8 @@ RUN apt update --yes > /dev/null && \
     libx11-dev libglpk-dev libgmp3-dev libxml2-dev \
     # R package units
     libudunits2-dev \
+    # R package sf
+    libgdal-dev libproj-dev gdal-bin \
     # R package magick
     libmagick++-dev imagemagick > /dev/null
 

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -5,9 +5,3 @@ dependencies:
 
 # pymc3 needs this
 - mkl-service==2.4.*
-
-# Cartopy and Shapely need this, and the versions on apt are too old
-# See https://github.com/berkeley-dsep-infra/datahub/issues/2824
-- proj==8.1.1
-- proj-data==1.6
-- geos==3.9.1

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -89,7 +89,7 @@ gspread==4.0.1
 # eps 109; fall 2019
 ffmpeg-python==0.2.0
 # see https://github.com/berkeley-dsep-infra/datahub/issues/1796
-Cartopy==0.20.0 --no-binary Cartopy
+Cartopy==0.19.0.post1 --no-binary Cartopy
 
 # data 88e; spring 2021
 plotly==5.2.1


### PR DESCRIPTION
Reverts berkeley-dsep-infra/datahub#2826

As predicted in a7af221ed0efbbce9b497fc0da33413ae34be35d.,
this broke R packages that depended on proj