### PR TITLE
Add tini to the user images

### DIFF
--- a/deployments/biology/image/Dockerfile
+++ b/deployments/biology/image/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
         libpython2.7 > /dev/null
 
-## libraries required for mothur 
+## libraries required for mothur
 ## libreadline6 required
 #RUN apt-get update -qq --yes > /dev/null && \
 #    apt-get install --yes -qq \
@@ -55,6 +55,7 @@ RUN apt-get update -qq --yes && \
         tmux \
         wget \
         vim \
+        tini \
         locales > /dev/null
 
 RUN echo "${LC_ALL} UTF-8" > /etc/locale.gen && \
@@ -160,7 +161,7 @@ RUN apt-get update && \
 RUN sed -i -e '/^R_LIBS_USER=/s/^/#/' /etc/R/Renviron && \
     echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron
 
-# Needed by Rhtslib 
+# Needed by Rhtslib
 RUN apt-get update -qq --yes && \
     apt-get install --yes  -qq \
         libcurl4-openssl-dev > /dev/null
@@ -182,7 +183,7 @@ COPY rsession.conf /etc/rstudio/rsession.conf
 
 #install rsession proxy
 RUN pip install --no-cache-dir \
-        jupyter-rsession-proxy==1.2 
+        jupyter-rsession-proxy==1.2
 
 # Install IRKernel
 RUN r -e "install.packages('IRkernel', version='1.1.1')" && \
@@ -198,7 +199,7 @@ ADD ipython_config.py ${CONDA_PREFIX}/etc/ipython/
 
 # install bio1b packages
 COPY bio1b-packages.bash /tmp/bio1b-packages.bash
-RUN bash /tmp/bio1b-packages.bash 
+RUN bash /tmp/bio1b-packages.bash
 
 # install ib134L packages
 COPY ib134-packages.bash /tmp/ib134-packages.bash
@@ -207,3 +208,5 @@ RUN bash /tmp/ib134-packages.bash
 # install ccb293 packages
 COPY ccb293-packages.bash /tmp/ccb293-packages.bash
 RUN bash /tmp/ccb293-packages.bash
+
+ENTRYPOINT ["/tini", "--"]

--- a/deployments/data8/image/Dockerfile
+++ b/deployments/data8/image/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get -qq update --yes && \
             vim \
             micro \
             mc \
+            tini \
             build-essential \
             locales > /dev/null
 
@@ -90,3 +91,5 @@ ENV PYPPETEER_HOME ${CONDA_DIR}
 RUN pyppeteer-install
 
 EXPOSE 8888
+
+ENTRYPOINT ["/tini", "--"]

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -qq update --yes && \
             vim \
             micro \
             mc \
+            tini \
             locales > /dev/null
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
@@ -105,7 +106,7 @@ RUN apt-get update -qq --yes && \
         libapparmor1 \
         lsb-release \
         libclang-dev  > /dev/null
-            
+
 # apt packages needed for R packages
 RUN apt update --yes > /dev/null && \
     apt install --no-install-recommends --yes \
@@ -254,5 +255,6 @@ ADD ipython_config.py ${IPYTHONDIR}/ipython_config.py
 # install QGrid notebook extension
 RUN jupyter nbextension enable --py --sys-prefix qgrid
 
-
 EXPOSE 8888
+
+ENTRYPOINT ["/tini", "--"]

--- a/deployments/julia/image/Dockerfile
+++ b/deployments/julia/image/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update -qq --yes && \
         tmux \
         wget \
         vim \
+        tini \
         build-essential \
         locales > /dev/null
 
@@ -62,3 +63,5 @@ RUN JUPYTER_DATA_DIR=${CONDA_DIR}/share/jupyter julia -e 'using Pkg; Pkg.add("IJ
 
 COPY install-julia-packages.jl /tmp/install-julia-packages.jl
 RUN /tmp/install-julia-packages.jl
+
+ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
RStudio daemonizes itself when it starts, so it isn't being
passed the SIGTERM when the user pod stops. So it exits
uncleanly, causing corruption and other state issues. tini should
properly reap the rstudio processes during exit.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2878
Ref https://github.com/berkeley-dsep-infra/datahub/issues/2891