### PR TITLE
Don't specify absolute path to tini

### DIFF
--- a/deployments/biology/image/Dockerfile
+++ b/deployments/biology/image/Dockerfile
@@ -209,4 +209,4 @@ RUN bash /tmp/ib134-packages.bash
 COPY ccb293-packages.bash /tmp/ccb293-packages.bash
 RUN bash /tmp/ccb293-packages.bash
 
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["tini", "--"]

--- a/deployments/data8/image/Dockerfile
+++ b/deployments/data8/image/Dockerfile
@@ -92,4 +92,4 @@ RUN pyppeteer-install
 
 EXPOSE 8888
 
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["tini", "--"]

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -257,4 +257,4 @@ RUN jupyter nbextension enable --py --sys-prefix qgrid
 
 EXPOSE 8888
 
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["tini", "--"]

--- a/deployments/julia/image/Dockerfile
+++ b/deployments/julia/image/Dockerfile
@@ -64,4 +64,4 @@ RUN JUPYTER_DATA_DIR=${CONDA_DIR}/share/jupyter julia -e 'using Pkg; Pkg.add("IJ
 COPY install-julia-packages.jl /tmp/install-julia-packages.jl
 RUN /tmp/install-julia-packages.jl
 
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
We get it from apt, so it should be somewhere else in $PATH

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2878
Ref https://github.com/berkeley-dsep-infra/datahub/issues/2891