### PR TITLE
Add tini to ischool & publichelath hubs

### DIFF
--- a/deployments/ischool/image/Dockerfile
+++ b/deployments/ischool/image/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update > /dev/null && \
             libssl1.1 \
             fonts-symbola \
             gdebi-core \
+            tini \
             nodejs npm > /dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -68,3 +69,6 @@ RUN install2.r --error --skipinstalled \
     Hmisc plm patchwork # For https://github.com/berkeley-dsep-infra/datahub/issues/2519 \
     fpp3 # For https://github.com/berkeley-dsep-infra/datahub/issues/2510 && \
     rm -rf /tmp/downloaded_packages
+
+
+ENTRYPOINT ["tini", "--"]

--- a/deployments/publichealth/image/Dockerfile
+++ b/deployments/publichealth/image/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update > /dev/null && \
             libssl1.1 \
             fonts-symbola \
             gdebi-core \
+            tini \
             nodejs npm > /dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -72,3 +73,5 @@ RUN r /tmp/r-packages/ph-142.r
 
 COPY r-packages/ph-252.r /tmp/r-packages/
 RUN r /tmp/r-packages/ph-252.r
+
+ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
We inherit from the geospatial rocker images, which ship
with the s6 process manager. However, JupyterHub doesn't
launch them using that. We consistently use tini across
all our images instead.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2878
Ref https://github.com/berkeley-dsep-infra/datahub/issues/2891