### PR TITLE
Mount all user home dirs in /srv/homes

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -4,6 +4,12 @@ nfsPVC:
     serverIP: nfsserver-01
 
 jupyterhub:
+  custom:
+    admin:
+      extraVolumeMounts:
+        - name: home
+          mountPath: /srv/homes
+
   scheduling:
     userScheduler:
       nodeSelector:


### PR DESCRIPTION
Helpful for admins to collect data from all users in
one go.

Fixes https://github.com/berkeley-dsep-infra/datahub/issues/2869