### PR TITLE
Allow *all* outbound access to the internet

### DIFF
--- a/deployments/data8x/config/common.yaml
+++ b/deployments/data8x/config/common.yaml
@@ -66,6 +66,22 @@ jupyterhub:
           # 2813 Eric Van Dusen
           - bd1e7c64c6f5faddbf6b32af3010cf75 #sean.smorris
   singleuser:
+    networkPolicy:
+      # We only allow outbound HTTP, HTTPS and DNS access
+      enabled: true
+      egress:
+        - ports:
+            - port: 80
+              protocol: TCP
+        - ports:
+            - port: 443
+              protocol: TCP
+        - ports:
+            # statsd ports
+            - port: 9125
+              protocol: TCP
+            - port: 9125
+              protocol: UDP
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -96,36 +96,6 @@ jupyterhub:
       limit: 1G
     image:
       name: gcr.io/ucb-datahub-2018/r-user-image
-    networkPolicy:
-      enabled: true
-      # NOTE: This is a partial repetition of what's in hub/values.yaml,
-      # add an item to a list. We add external ssh access here, something I don't
-      # want to allow in general as an anti-abuse measure.
-      egress:
-        - ports:
-            - port: 80
-              protocol: TCP
-        - ports:
-            - port: 443
-              protocol: TCP
-        - ports:
-            # Allow outbound SSH https://github.com/berkeley-dsep-infra/datahub/issues/2814
-            - port: 22
-              protocol: TCP
-        - ports:
-            # Allow FTP access https://github.com/berkeley-dsep-infra/datahub/issues/1789
-            - port: 21
-              protocol: TCP
-        # enabling ssh for private git repos
-        - ports:
-            - port: 22
-              protocol: TCP
-        - ports:
-            # statsd ports
-            - port: 9125
-              protocol: TCP
-            - port: 9125
-              protocol: UDP
   custom:
     # this should be migrated to custom.profiles when that works
     profiles:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -108,6 +108,21 @@ jupyterhub:
               protocol: TCP
             - port: 80
               protocol: TCP
+        # datahub.berkeley.edu is still not using the ingress provider, so
+        # we have to explicitly allow access to it from our user pods.
+        - to:
+          - podSelector:
+              matchLabels:
+                app: jupyterhub
+                component: autohttps
+            namespaceSelector:
+              matchLabels:
+                name: datahub-prod
+          ports:
+            - port: http
+              protocol: TCP
+            - port: https
+              protocol: TCP
         # Allow user code to send packets to statsd for python-popularity-contest
         - to:
           - namespaceSelector:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -89,35 +89,50 @@ jupyterhub:
       PYTHON_POPCONTEST_STATSD_PORT: '9125'
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     networkPolicy:
-      # In clusters with NetworkPolicy enabled, do not
-      # allow outbound internet access that's not DNS, FTP, HTTP or HTTPS
-      # We can override this on a case to case basis where
-      # required.
       enabled: true
-      # NOTE: This needs to be repeated in r/config/common.yaml, since we can't
-      # add an item to a list. It needs external ssh access, something I don't
-      # want to allow in general as an anti-abuse measure.
+      # We enable all outgoing access to the broader internet, but not to private IP ranges
+      # of pods and services inside the cluster - except for outbound UDP and TCP to statsd,
+      # for python-popularity-package.
       egress:
-        - ports:
-            - port: 80
-              protocol: TCP
-        - ports:
+        # Allow code in hubs to talk to ingress provider, so they can talk to the hub via its
+        # public URL
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                name: support
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: ingress-nginx
+          ports:
             - port: 443
               protocol: TCP
-        - ports:
-            # Allow outbound SSH https://github.com/berkeley-dsep-infra/datahub/issues/2814
-            - port: 22
+            - port: 80
               protocol: TCP
-        - ports:
-            # Allow FTP access https://github.com/berkeley-dsep-infra/datahub/issues/1789
-            - port: 21
-              protocol: TCP
-        - ports:
+        # Allow user code to send packets to statsd for python-popularity-contest
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                name: support
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: prometheus-statsd-exporter
+          ports:
             # statsd ports
             - port: 9125
               protocol: TCP
             - port: 9125
               protocol: UDP
+        - to:
+          - ipBlock:
+              cidr: 0.0.0.0/0
+              except:
+              # Don't allow network access to private IP ranges
+              # Listed in https://datatracker.ietf.org/doc/html/rfc1918
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              # Don't allow network access to the metadata IP
+              - 169.254.169.254/32
   hub:
     # The default of 64 is way too low for us
     concurrentSpawnLimit: 200


### PR DESCRIPTION
- Disallow all access to internal network except when explicitly
  allowed - so this is all k8s pods, services, nodes and possibly other
  services in the same private network.
- Allow talking to the ingress controller, so hubs can talk to their own
  public URLs - without this, python code running in
  data8.datahub.berkeley.edu can not actually make HTTP requests to
  data8.datahub.berkeley.edu! However, this doesn't work for datahub
  yet, as it uses its own IP with autohttps and not the ingress
  controller.
- Keep data8x restricted on outbound access. This hub is open to the
  wider public, not just Berkeley students.

TODO:

- Unclear if outgoing traffic to statsd is working or not. Needs to
  be investigated.

Thanks to @sgibson91 for
https://github.com/2i2c-org/infrastructure/pull/774,
where parts of this are stolen from

Fixes https://github.com/berkeley-dsep-infra/datahub/issues/2825#event-5429999808