### PR TITLE
Bump required version of httplib2

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -233,6 +233,14 @@ RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
+# Temporarily install httplib2 from a PR until a new release is made
+# https://github.com/berkeley-dsep-infra/datahub/issues/2950
+# Undo this and require a higher version of httplib2 once it is merged and released
+# As we have other modules using pyparsing, installing this small patch over the
+# existing version is much safer than pinning to an older one
+RUN pip install -U --force git+https://github.com/busunkim96/httplib2.git@pp-downcaseTokens
+
+
 # Set up nbpdf dependencies
 ENV PYPPETEER_HOME ${CONDA_DIR}
 RUN pyppeteer-install

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -233,14 +233,6 @@ RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
-# Temporarily install httplib2 from a PR until a new release is made
-# https://github.com/berkeley-dsep-infra/datahub/issues/2950
-# Undo this and require a higher version of httplib2 once it is merged and released
-# As we have other modules using pyparsing, installing this small patch over the
-# existing version is much safer than pinning to an older one
-RUN pip install -U --force git+https://github.com/busunkim96/httplib2.git@pp-downcaseTokens
-
-
 # Set up nbpdf dependencies
 ENV PYPPETEER_HOME ${CONDA_DIR}
 RUN pyppeteer-install

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -194,3 +194,7 @@ pooch==1.5.2
 
 # PS88 https://github.com/berkeley-dsep-infra/datahub/issues/2925
 linearmodels==4.24
+
+# https://github.com/berkeley-dsep-infra/datahub/issues/2950
+# Needed to work with a new enough version of httplib2
+httplib2>=0.20.2


### PR DESCRIPTION
Brings in https://github.com/httplib2/httplib2/pull/209, which makes httplib2
support new enough pyparsing that our other libraries want.

Fixes https://github.com/berkeley-dsep-infra/datahub/issues/2950