### PR TITLE
Use containerd for all our nodes

### DIFF
--- a/docs/admins/cluster-config.rst
+++ b/docs/admins/cluster-config.rst
@@ -46,18 +46,18 @@ the currently favored configuration.
 
     gcloud container node-pools create  \
         --machine-type n1-highmem-8 \
-        --num-nodes 2 \
+        --num-nodes 1 \
         --enable-autoscaling \
         --min-nodes 1 --max-nodes 20 \
-        --node-labels hub.jupyter.org/pool-name=beta-pool \
+        --node-labels hub.jupyter.org/pool-name=<pool-name>-pool \
         --node-taints hub.jupyter.org_dedicated=user:NoSchedule \
         --region=us-central1 \
-        --image-type=cos \
+        --image-type=cos_containerd \
         --disk-size=200 --disk-type=pd-balanced \
         --no-enable-autoupgrade \
         --tags=hub-cluster \
         --cluster=fall-2019 \
-        user-pool-<pool-name>-<yyyy>-<mm>-<dd>
+        user-<pool-name>-<yyyy>-<mm>-<dd>
 
 
 IP Aliasing


### PR DESCRIPTION
- Remove the word 'pool' from the user pool nodepool name. Just
  adds clutter, and cuts off the full date from node names as kubernetes
  objects have a 63 char max limit
- Use 1 rather than 2 as default node startup count.

I've manually created alpha, beta and delta pools to match what we
have. This also bumps the k8s version on them.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2958