### PR TITLE
Pin setuptools temporarily

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -31,3 +31,5 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+setuptools<=58.4


### PR DESCRIPTION
New builds are failing with this error message
(https://app.circleci.com/pipelines/github/berkeley-dsep-infra/datahub/744/workflows/ee2f988b-b888-4e39-a8ce-fb8bca401fb2/jobs/5993)

```
      self.add_defaults()
    File "/tmp/pip-build-env-rvc3nf2q/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults
      sdist.add_defaults(self)
    File "/opt/conda/lib/python3.9/distutils/command/sdist.py", line 226, in add_defaults
      self._add_defaults_python()
    File "/tmp/pip-build-env-rvc3nf2q/overlay/lib/python3.9/site-packages/setuptools/command/sdist.py", line 113, in _add_defaults_python
      self._add_data_files(self._safe_data_files(build_py))
    File "/tmp/pip-build-env-rvc3nf2q/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 621, in _safe_data_files
      return build_py.get_data_files_without_manifest()
    File "/opt/conda/lib/python3.9/distutils/cmd.py", line 103, in __getattr__
      raise AttributeError(attr)
  AttributeError: get_data_files_without_manifest
```

Googling leads to https://github.com/pypa/setuptools/issues/2849,
which matches our problem. Let's pin setuptools to an older
version until this gets fixed.