### PR TITLE
Pin setuptools before installing JupyterHub

### DIFF
--- a/deployments/biology/image/Dockerfile
+++ b/deployments/biology/image/Dockerfile
@@ -176,7 +176,7 @@ COPY requirements.txt /tmp/
 COPY infra-requirements.txt /tmp/
 
 # Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-RUN pip install --force 'setuptools<=58.4'
+RUN pip install --force 'setuptools<=57'
 
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml
 RUN jupyter contrib nbextensions install --sys-prefix --symlink && \

--- a/deployments/biology/image/Dockerfile
+++ b/deployments/biology/image/Dockerfile
@@ -175,6 +175,9 @@ COPY environment.yml /tmp/
 COPY requirements.txt /tmp/
 COPY infra-requirements.txt /tmp/
 
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+RUN pip install --force 'setuptools<=58.4'
+
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml
 RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
     jupyter nbextensions_configurator enable --sys-prefix

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/data8/image/Dockerfile
+++ b/deployments/data8/image/Dockerfile
@@ -81,7 +81,7 @@ COPY environment.yml /tmp/environment.yml
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml
 
 # Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-RUN pip install --force 'setuptools<=58.4'
+RUN pip install --force 'setuptools<=57'
 
 COPY infra-requirements.txt /tmp/infra-requirements.txt
 RUN pip install --no-cache -r /tmp/infra-requirements.txt

--- a/deployments/data8/image/Dockerfile
+++ b/deployments/data8/image/Dockerfile
@@ -80,6 +80,9 @@ COPY environment.yml /tmp/environment.yml
 
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml
 
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+RUN pip install --force 'setuptools<=58.4'
+
 COPY infra-requirements.txt /tmp/infra-requirements.txt
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
 

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -228,7 +228,7 @@ RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml
 COPY infra-requirements.txt /tmp/infra-requirements.txt
 
 # Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-RUN pip install --force 'setuptools<=58.4'
+RUN pip install --force 'setuptools<=57'
 
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
 RUN jupyter contrib nbextensions install --sys-prefix --symlink && \

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -226,6 +226,10 @@ COPY environment.yml /tmp/environment.yml
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml
 
 COPY infra-requirements.txt /tmp/infra-requirements.txt
+
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+RUN pip install --force 'setuptools<=58.4'
+
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
 RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
     jupyter nbextensions_configurator enable --sys-prefix

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/ischool/image/Dockerfile
+++ b/deployments/ischool/image/Dockerfile
@@ -54,6 +54,10 @@ RUN /tmp/install-mambaforge.bash
 USER ${NB_USER}
 
 COPY infra-requirements.txt /tmp/infra-requirements.txt
+
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+RUN pip install --force 'setuptools<=58.4'
+
 RUN pip install --no-cache-dir -r /tmp/infra-requirements.txt
 
 COPY requirements.txt /tmp/requirements.txt

--- a/deployments/ischool/image/Dockerfile
+++ b/deployments/ischool/image/Dockerfile
@@ -56,7 +56,7 @@ USER ${NB_USER}
 COPY infra-requirements.txt /tmp/infra-requirements.txt
 
 # Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-RUN pip install --force 'setuptools<=58.4'
+RUN pip install --force 'setuptools<=57'
 
 RUN pip install --no-cache-dir -r /tmp/infra-requirements.txt
 

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/julia/image/Dockerfile
+++ b/deployments/julia/image/Dockerfile
@@ -47,6 +47,10 @@ COPY environment.yml /tmp/environment.yml
 RUN mamba env update -p ${CONDA_DIR}  -f /tmp/environment.yml
 
 COPY infra-requirements.txt /tmp/infra-requirements.txt
+
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+RUN pip install --force 'setuptools<=58.4'
+
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
 RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
     jupyter nbextensions_configurator enable --sys-prefix

--- a/deployments/julia/image/Dockerfile
+++ b/deployments/julia/image/Dockerfile
@@ -49,7 +49,7 @@ RUN mamba env update -p ${CONDA_DIR}  -f /tmp/environment.yml
 COPY infra-requirements.txt /tmp/infra-requirements.txt
 
 # Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-RUN pip install --force 'setuptools<=58.4'
+RUN pip install --force 'setuptools<=57'
 
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
 RUN jupyter contrib nbextensions install --sys-prefix --symlink && \

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/publichealth/image/Dockerfile
+++ b/deployments/publichealth/image/Dockerfile
@@ -54,6 +54,10 @@ RUN /tmp/install-mambaforge.bash
 USER ${NB_USER}
 
 COPY infra-requirements.txt /tmp/infra-requirements.txt
+
+# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
+RUN pip install --force 'setuptools<=58.4'
+
 RUN pip install --no-cache-dir -r /tmp/infra-requirements.txt
 
 COPY requirements.txt /tmp/requirements.txt

--- a/deployments/publichealth/image/Dockerfile
+++ b/deployments/publichealth/image/Dockerfile
@@ -56,7 +56,7 @@ USER ${NB_USER}
 COPY infra-requirements.txt /tmp/infra-requirements.txt
 
 # Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-RUN pip install --force 'setuptools<=58.4'
+RUN pip install --force 'setuptools<=57'
 
 RUN pip install --no-cache-dir -r /tmp/infra-requirements.txt
 

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4


### PR DESCRIPTION
The setuptools bug was being triggered by us installing
JupyterHub from git. In
https://github.com/berkeley-dsep-infra/datahub/pull/2963,
we pinned setuptools in the same file as we install JupyterHub -
this is too late as setuptools has already been invoked to install
JupyterHub!

So we install setuptools before we setup infra-packages.