### PR TITLE
Bump to JupyterHub 1.5.0

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update > /dev/null  && apt install --yes npm > /dev/null
 
 # Brings in https://github.com/jupyterhub/jupyterhub/pull/3579
 # and https://github.com/jupyterhub/jupyterhub/pull/3639
-RUN python3 -m pip install --no-cache --force-reinstall --upgrade git+https://github.com/jupyterhub/jupyterhub.git@69a1e97fbee1711e3fdb5fd795e349a4eb395060
+RUN python3 -m pip install --no-cache --force-reinstall --upgrade jupyterhub==1.5.0
 
 COPY canvasauthenticator /srv/canvasauthenticator
 RUN python3 -m pip install --no-cache /srv/canvasauthenticator

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -17,7 +17,7 @@ retrolab==0.3.5
 nbgitpuller==0.10.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
-git+https://github.com/meeseeksmachine/jupyterhub@auto-backport-of-pr-3488-on-1.4.x
+jupyterhub==1.5.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==3.1.4
@@ -31,5 +31,3 @@ jupyter_nbextensions_configurator==0.4.1
 popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
-# Remove once https://github.com/pypa/setuptools/issues/2849 is fixed
-setuptools<=58.4


### PR DESCRIPTION
Setuptools bug is triggered by installing from git,
and JupyterHub was just released a few hours ago!

Much easier than trying to figure out how to pin
setuptools to be exactly right https://github.com/berkeley-dsep-infra/datahub/pull/2964

This reverts commit 4c1e3a885d94ba901f0d6aa23417e3fe2bbfdbee.