### PR TITLE
Give data8 students more CPU

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -140,7 +140,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: delta-pool
+      hub.jupyter.org/pool-name: gamma-pool
     storage:
       type: static
       static:

--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -146,6 +146,10 @@ jupyterhub:
       static:
         pvcName: home-nfs
         subPath: "{username}"
+    cpu:
+      # https://github.com/berkeley-dsep-infra/datahub/issues/2966
+      guarantee: 0.5
+      limit: 0.5
     memory:
       guarantee: 512M
       limit: 1G

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -90,12 +90,12 @@ nodePools:
       hub.jupyter.org/pool-name: gamma-pool
     resources:
       requests:
-        memory: 46786Mi
-    replicas: 0
+        memory: 13000Mi
+    replicas: 1
   delta:
     nodeSelector:
       hub.jupyter.org/pool-name: delta-pool
     resources:
       requests:
         memory: 46786Mi
-    replicas: 1
+    replicas: 0


### PR DESCRIPTION
Reported on the data8 slack that many users are having trouble running
*any* cells at all. Apparently there is a project deadline today with many simulations,
and a few users have pegged CPU because we don't really have any CPU limits.

The CPU limit and guarantee matching will ensure that no set of users can
take over a full node, and everyone gets the same amount of CPU - only fair
when you are doing homework. I've also created a new nodepool with 16GB of
RAM and 16 cpu cores to better match the CPU / RAM guarantee ratio we have
for our user pods.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2966