### PR TITLE
Reduce data8 CPU requests & move back to delta pool

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -140,7 +140,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: delta-pool
     storage:
       type: static
       static:
@@ -148,7 +148,7 @@ jupyterhub:
         subPath: "{username}"
     cpu:
       # https://github.com/berkeley-dsep-infra/datahub/issues/2966
-      guarantee: 0.5
+      guarantee: 0.1
       limit: 0.5
     memory:
       guarantee: 512M


### PR DESCRIPTION
- The 0.1 guarantee ensures that nobody gets 0 CPU and can't
  execute *any* cells. We should consider doing this for all our
  hubs.
- The 1 limit ensures that a single user can't take over all the
  CPU in a node. A bunch of them (8) can in fact take over all
  the CPU in a node, but hopefully the guaarantee prevents that.
  The project with a lot of simulations is also over now,
  which should help.
- Moves people back to a delta pool that I created with n1-highmem-8,
  matching older CPU & RAM specs

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2966