### PR TITLE
Tweak data8 CPU limits again

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -38,7 +38,7 @@ jupyterhub:
           - yuvipanda
           - felder
           - balajialwar
-          # Fall 2021 Admins, from Meghan Wang  
+          # Fall 2021 Admins, from Meghan Wang
           - daw
           - nellepersson
           - meghanwang
@@ -148,8 +148,8 @@ jupyterhub:
         subPath: "{username}"
     cpu:
       # https://github.com/berkeley-dsep-infra/datahub/issues/2966
-      guarantee: 0.1
-      limit: 0.5
+      guarantee: 0.05
+      limit: 1
     memory:
       guarantee: 512M
       limit: 1G


### PR DESCRIPTION
- 0.1 meant our nodes were filling up with CPU commitments
  before they filled with RAM commitments. Since data8 and most
  of our classes are memory bound and not CPU bound, this wastes
  resources - nodes scale up earlier thant they need to. Since the
  goal of the CPU guarantee was to make sure students can always
  execute *some* code, 0.05 should also fit the bill without
  screwing up our RAM ratios. There's probably a more precise
  way to do this.
- Let's give each data8 user a 1 CPU limit, rather than a 0.5 one.
  This lets them explore a little simulations a little better,
  and it looks like we don't have a lot of them doing this
  together right now. There's also a pagerdutty alert for full
  CPUs now

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2966