### PR TITLE
Set CPU guarantees and limits for all hubs

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -51,6 +51,15 @@ jupyterhub:
       letsencrypt:
         contactEmail: yuvipanda@berkeley.edu
   singleuser:
+    cpu:
+      # Make sure all users get at least 5% of CPU, so other users can't starve them
+      # so much that they crash
+      guarantee: 0.05
+      # We use CPUs with 8 cores, and want to make sure that a single user can't take
+      # over a node (more than one still can). But we also want to give users the
+      # option of using as much CPU as they need if nobody else is using the node, as
+      # is often the case. 7 seems a reasonable compromise here.
+      limit: 7
     extraFiles:
       culling-config:
         mountPath: /etc/jupyter/jupyter_notebook_config.json


### PR DESCRIPTION
We want to avoid situations like https://github.com/berkeley-dsep-infra/datahub/issues/2966
where data8 students could not execute *anything* because some other
users have taken over the CPU by running compute intense stuff. This
has happened before to eecs hub
(https://github.com/berkeley-dsep-infra/datahub/issues/2322),
and we had to move them to their own nodepool for that. Sometimes the
CPU gets so starved that user pods don't even launch, as there is not
enough CPU for the notebook server process to do its things within
the 30s server start timeout period the hub expects to hear from the
started server.

By giving each user a 5% CPU guarantee, we make sure that everyone
has at least *some* CPU. We run n1-highmem-8 nodes, which means the
scheduler can put upto 160 user pods on each node. As kubernetes has
a hard limit of 100 pods per node, this means we don't really affect
our scaling mechanism at all. We have memory bound workloads, we want
memory commit to trigger autoscalers, and that will continue to be
the case.

The 7 CPU limit will also help make sure that a *single* user can
not take over the entire node - needs at least 2 users. But a lot of
times, our CPUs are idle, and we don't want to limit users from
using them. 7 seems a reasonable compromise given we have 8 CPUs,
but I must investigate if containerd (which is what we use now, not
docker)enforces CPU guarantees as well - I only want users to use
upto 7 CPUs if they aren't starving others of at least the 5% CPU.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2966