### PR TITLE
Put gcloud inside the venv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ orbs:
                   name: Install google cloud sdk
                   command: |
                     export GCLOUD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-363.0.0-linux-x86_64.tar.gz
-                    curl -sSL $GCLOUD_URL | tar -xzf -
+                    curl -sSL $GCLOUD_URL | tar -xzf - -C venv
                     # Be careful with quote ordering here. ${PATH} must not be expanded
                     # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
                     # Always use full PATHs in PATH!
@@ -131,7 +131,7 @@ jobs:
             pip install --upgrade git+https://github.com/docker/docker-py.git@b6f6e7270ef1acfe7398b99b575d22d0d37ae8bf
 
             export GCLOUD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-363.0.0-linux-x86_64.tar.gz
-            curl -sSL $GCLOUD_URL | tar -xzf -
+            curl -sSL $GCLOUD_URL | tar -xzf - -C venv
             # Be careful with quote ordering here. ${PATH} must not be expanded
             # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
             # Always use full PATHs in PATH!
@@ -258,7 +258,7 @@ jobs:
           name: install google-cloud-sdk
           command: |
             export GCLOUD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-363.0.0-linux-x86_64.tar.gz
-            curl -sSL $GCLOUD_URL | tar -xzf -
+            curl -sSL $GCLOUD_URL | tar -xzf - -C venv
             # Be careful with quote ordering here. ${PATH} must not be expanded
             # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
             # Always use full PATHs in PATH!
@@ -314,7 +314,7 @@ jobs:
           name: install google-cloud-sdk
           command: |
             export GCLOUD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-363.0.0-linux-x86_64.tar.gz
-            curl -sSL $GCLOUD_URL | tar -xzf -
+            curl -sSL $GCLOUD_URL | tar -xzf - -C venv
             # Be careful with quote ordering here. ${PATH} must not be expanded
             # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
             # Always use full PATHs in PATH!


### PR DESCRIPTION
That's where our PATH is expecting it. I don't know how this
worked since the gcloud sdk update at all.