### PR TITLE
Limit biology hub users to 4 CPUs

### DIFF
--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -59,3 +59,8 @@ jupyterhub:
     memory:
       guarantee: 2056M
       limit: 4G
+    cpu:
+      # Biology hub users can consume quite a bit of CPU at times, starving out other
+      # users on the nodes. So we reduce the max amount of CPU available to them, from 7
+      # (defined in hub/values.yaml) to 4.
+      limit: 4


### PR DESCRIPTION
A couple of biology hub users have been saturating the CPU on
the nodes they're on, impacting performance on other hubs in
the beta nodepool (ischool and public health). Bringing them
down to a limit of 4 CPUs should help. If this continues, we can
just move biology to its own nodepool.