### PR TITLE
[Package request] phangorn 2.7.1 (fixed)

### DIFF
--- a/deployments/biology/image/install.R
+++ b/deployments/biology/image/install.R
@@ -22,6 +22,7 @@ cran_packages <- c(
   "mixtools","1.2.0",
   "mclust","5.4.7",
   "pheatmap","1.0.12"
+  "phangorn","2.7.1"
 )
 
 for (i in seq(1, length(cran_packages), 2)) {

--- a/deployments/biology/image/install.R
+++ b/deployments/biology/image/install.R
@@ -21,7 +21,7 @@ cran_packages <- c(
   "plotly","4.9.3",
   "mixtools","1.2.0",
   "mclust","5.4.7",
-  "pheatmap","1.0.12"
+  "pheatmap","1.0.12",
   "phangorn","2.7.1"
 )
 


### PR DESCRIPTION
fixed: was missing a comma

phangorn dependency for phytools. phangorn 2.8.0 requires R 4.1.0, we're currently on 4.0.5. I don't want to break anything else, so I tested that 2.7.1. works right now. Sorry for the constant PRs!