### PR TITLE
Enable Real Time Collaboration on DataHub

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -88,6 +88,9 @@ jupyterhub:
       nodeSelector:
         hub.jupyter.org/pool-name: core-pool
   singleuser:
+    cmd:
+    - jupyterhub-singleuser
+    - --LabApp.collaborative=true
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool
     storage:

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -11,7 +11,8 @@
 notebook==6.4.5
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.2
+jupyterlab==3.2.4
+jupyterlab-link-share==0.2.1
 nbconvert==6.1.0
 retrolab==0.3.13
 nbgitpuller==1.0.2


### PR DESCRIPTION
- Bump up JupyterLab to get latest bugfixes
- Enable the --collaborative flag
- Install jupyterlab-link-share, required to generate the link
  you can give others to collaborate with you. It adds a
  'Share' menu item to JupyterLab, and also a 'Copy downloadable link'
  item to the context menu. More info at https://pypi.org/project/jupyterlab-link-share/

Ref https://github.com/berkeley-dsep-infra/datahub/issues/3027