### PR TITLE
Enable RTC in data100 hub, not datahub

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -33,6 +33,9 @@ jupyterhub:
         tag: 0.0.1-n3657.h4f7f88c
   singleuser:
     defaultUrl: "/lab"
+    cmd:
+    - jupyterhub-singleuser
+    - --LabApp.collaborative=true
     extraContainers:
       - name: postgres
         image: gcr.io/ucb-datahub-2018/jupyterhub-postgres:0.0.1-n3657.h4f7f88c

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -88,9 +88,6 @@ jupyterhub:
       nodeSelector:
         hub.jupyter.org/pool-name: core-pool
   singleuser:
-    cmd:
-    - jupyterhub-singleuser
-    - --LabApp.collaborative=true
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool
     storage:


### PR DESCRIPTION
@fperez is very happy to dogfood this. Let's try it out
here instead of in the main datahub