### PR TITLE
Bump version of jupyterlab-link-share

### DIFF
--- a/deployments/data8/image/Dockerfile
+++ b/deployments/data8/image/Dockerfile
@@ -91,6 +91,6 @@ EXPOSE 8888
 
 # Temporarily install newer version of jupyterlab-link-share
 # Move this back to just installing off infra-requirements once we are a bit stable
-RUN pip install -U jupyterlab-link-share==0.2.3
+RUN pip install -U jupyterlab-link-share==0.2.4
 
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
Brings in https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/27
as retrolab is going to be (hopefully) used by data8

Ref https://github.com/berkeley-dsep-infra/datahub/issues/3027