### PR TITLE
Disable collaboration in data100

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -33,9 +33,6 @@ jupyterhub:
         tag: 0.0.1-n3657.h4f7f88c
   singleuser:
     defaultUrl: "/lab"
-    cmd:
-    - jupyterhub-singleuser
-    - --LabApp.collaborative=true
     extraContainers:
       - name: postgres
         image: gcr.io/ucb-datahub-2018/jupyterhub-postgres:0.0.1-n3657.h4f7f88c


### PR DESCRIPTION
Users are reporting some save issues on Piazza, and I
wasn't able to debug this right now. Turning this off to
see if it helps.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/3027