### PR TITLE
Bumping eecs cpu allocation back up.  Issues #2322 and #3049.

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -72,7 +72,8 @@ jupyterhub:
     memory:
       guarantee: 512M
       limit: 2G
+    # eecs 16a needs this until December 10.
     cpu:
-      limit: 1
-      guarantee: 0.33
+      limit: 2
+      guarantee: 2
     image: {}


### PR DESCRIPTION
eecs 16a needs it until 12/10 (basically end of semester).