### PR TITLE
Changed gofer_nb url to gofer_service with otter grader

### DIFF
--- a/deployments/data8x/config/common.yaml
+++ b/deployments/data8x/config/common.yaml
@@ -22,7 +22,7 @@ jupyterhub:
   hub:
     services:
       gofer_nb:
-        url: http://35.239.20.122:10101
+        url: http://grading.data8x.berkeley.edu:10101
     config:
       JupyterHub:
         authenticator_class: ltiauthenticator.LTIAuthenticator


### PR DESCRIPTION
The gofer_nb url in common.yaml now points to the updated
gofer_servce that is using otter grader