### PR TITLE
Improve rsync script to be parallel

### DIFF
--- a/scripts/rsync-active-users.py
+++ b/scripts/rsync-active-users.py
@@ -140,10 +140,10 @@ def main():
         if not os.path.exists(src_homedir):
             print(f"Directory {src_homedir} does not exist for user {user}, aborting")
             sys.exit(1)
-        dest_homedir = os.path.join(args.dest_basedir, homedir)
         rsync_cmd = [
             'rsync', '-av',
             '--delete', '--ignore-errors',
+            '--exclude=*/.cache/*',
             src_homedir, args.dest_basedir
         ]
         print('Running ' + ' '.join(rsync_cmd))

--- a/scripts/rsync-active-users.py
+++ b/scripts/rsync-active-users.py
@@ -110,7 +110,6 @@ def rsync(user, src_basedir, dest_basedir, dry_run):
         '--exclude=*/.cache/*',
         src_homedir, dest_basedir
     ]
-    print('Running ' + ' '.join(rsync_cmd))
     if not dry_run:
         subprocess.check_output(rsync_cmd)
         print(f'Finished rsync for {user}')
@@ -159,6 +158,7 @@ def main():
 
     pool = ThreadPoolExecutor(max_workers=args.concurrency)
     futures = []
+    completed_futures = 0
 
     for user in users_since:
         # Escaping logic from https://github.com/jupyterhub/kubespawner/blob/0eecad35d8829d8d599be876ee26c192d622e442/kubespawner/spawner.py#L1340
@@ -172,6 +172,8 @@ def main():
 
     for future in as_completed(futures):
         future.result()
+        completed_futures += 1
+        print(f'Finished {completed_futures} of {len(users_since)}')
 
     if not args.actually_run_rsync:
         print("No rsync commands were actually performed")

--- a/scripts/rsync-active-users.py
+++ b/scripts/rsync-active-users.py
@@ -112,7 +112,7 @@ def rsync(user, src_basedir, dest_basedir, dry_run):
     ]
     if not dry_run:
         subprocess.check_output(rsync_cmd)
-        print(f'Finished rsync for {user}')
+    return user
 
 def main():
     argparser = argparse.ArgumentParser()
@@ -171,9 +171,9 @@ def main():
         futures.append(future)
 
     for future in as_completed(futures):
-        future.result()
+        completed_user = future.result()
         completed_futures += 1
-        print(f'Finished {completed_futures} of {len(users_since)}')
+        print(f'Finished {completed_futures} of {len(users_since)} - user ${completed_user}')
 
     if not args.actually_run_rsync:
         print("No rsync commands were actually performed")

--- a/scripts/rsync-active-users.py
+++ b/scripts/rsync-active-users.py
@@ -109,7 +109,6 @@ def rsync(user, src_basedir, dest_basedir, dry_run):
     rsync_cmd = [
         'rsync', '-av',
         '--delete', '--ignore-errors',
-        '--exclude=*/.cache/*',
         src_homedir, dest_basedir
     ]
     if not dry_run:

--- a/scripts/rsync-active-users.py
+++ b/scripts/rsync-active-users.py
@@ -112,7 +112,7 @@ def rsync(user, src_basedir, dest_basedir, dry_run):
     ]
     print('Running ' + ' '.join(rsync_cmd))
     if not dry_run:
-        subprocess.check_call(rsync_cmd)
+        subprocess.check_output(rsync_cmd)
         print(f'Finished rsync for {user}')
 
 def main():


### PR DESCRIPTION
By using recency data from a JupyterHub API, we can improve the speed of
copying user home directories from one disk to another by an two or three
orders of magnitude! 