### PR TITLE
Disable RTC & JupyterLab link share everywhere except dlab & ischool

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -139,9 +139,6 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
-    cmd:
-    - jupyterhub-singleuser
-    - --LabApp.collaborative=true
     nodeSelector:
       hub.jupyter.org/pool-name: delta-pool
     storage:

--- a/deployments/dlab/config/common.yaml
+++ b/deployments/dlab/config/common.yaml
@@ -32,6 +32,12 @@ jupyterhub:
             # List of other admin users
 
   singleuser:
+    # Enable jupyterlab-link-share so people can share links for RTC
+    extraFiles:
+      lab-config:
+        data:
+          disabledExtensions:
+            jupyterlab-link-share: false
     cmd:
     - jupyterhub-singleuser
     - --LabApp.collaborative=true

--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -46,6 +46,12 @@ jupyterhub:
           - dhughes  # https://github.com/berkeley-dsep-infra/datahub/issues/2462
 
   singleuser:
+    # Enable jupyterlab-link-share so people can share links for RTC
+    extraFiles:
+      lab-config:
+        data:
+          disabledExtensions:
+            jupyterlab-link-share: false
     cmd:
     - jupyterhub-singleuser
     - --LabApp.collaborative=true

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -61,6 +61,11 @@ jupyterhub:
       # is often the case. 7 seems a reasonable compromise here.
       limit: 7
     extraFiles:
+      lab-config:
+        mountPath: /etc/jupyter/labconfig/page_config.json
+        data:
+          disabledExtensions:
+            jupyterlab-link-share: true
       culling-config:
         mountPath: /etc/jupyter/jupyter_notebook_config.json
         data:


### PR DESCRIPTION
See https://github.com/berkeley-dsep-infra/datahub/issues/3027#issuecomment-994409893