### PR TITLE
Tell Julia Hub where to open GUI windows

### DIFF
--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -30,6 +30,10 @@ jupyterhub:
             # List of other admin users
 
   singleuser:
+    extraEnv:
+      # Tell code where to display GUIs
+      # The VNC /desktop link must be opened already for this to work
+      DISPLAY: ":1.0"
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
     storage:


### PR DESCRIPTION
Copied from EECS config

Ref Ref https://github.com/berkeley-dsep-infra/datahub/issues/3079