### PR TITLE
Move most package management to conda/mamba.

### DIFF
--- a/deployments/astro/image/infra-requirements.txt
+++ b/deployments/astro/image/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/astro/image/infra-requirements.txt
+++ b/deployments/astro/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -44,8 +44,6 @@ dependencies:
   - jupyterlab-geojson=3.2.0
   - jupyterlab-git=0.34.2
   - jupyterlab-link-share==0.2.4
-  - jupyterlab-system-monitor=0.8.0
-  - jupyterlab-topbar=0.6.1
   - jupyterlab-variableinspector=3.0.9
   - jupyterlab_pygments=0.1.2
   - jupyterlab_widgets=1.0.2

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -89,6 +89,8 @@ dependencies:
   - xarray=0.20.2
   - xlrd=2.0.1
 
+  - micro=2.0.8
+
   - pip
   - pip:
     - -r infra-requirements.txt

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - ipywidgets=7.6.5
   - jupyter-book=0.12.1
   - jupyter-repo2docker=2021.8.0
-  - jupyter-resource-usage=0.6.0
+  - jupyter-resource-usage=0.6.1
   - jupyter-sphinx=0.3.2
   - jupyter_bokeh=3.0.4
   - jupyterlab=3.2.8

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - ipywidgets=7.6.5
   - jupyter-book=0.12.1
   - jupyter-repo2docker=2021.8.0
-  - jupyter-resource-usage=0.5.1
+  - jupyter-resource-usage=0.6.0
   - jupyter-sphinx=0.3.2
   - jupyter_bokeh=3.0.4
   - jupyterlab=3.2.8
@@ -94,4 +94,3 @@ dependencies:
   - pip
   - pip:
     - -r infra-requirements.txt
-    - -r book-requirements.txt

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -74,8 +74,6 @@ dependencies:
   - pillow=8.4.0
   - plotly=5.5.0
   - pooch=1.5.2
-  - proj=8.2.1
-  - pyproj=3.3.0
   - pytables=3.6.1
   - pytest=6.2.5
   - pytest-cov=3.0.0

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -1,11 +1,105 @@
+name: stat159-s22
+
 channels:
-- conda-forge
+  - conda-forge
 
 dependencies:
-- python=3.9.*
+  - python=3.9.9
 
-- numpy==1.22.*
-- matplotlib==3.5.*
-- pip
-- pip:
-  - -r infra-requirements.txt
+  - altair=4.2.0
+  - beautifulsoup4=4.10.0
+  - black=21.12b0
+  - bokeh=2.4.2
+  - bqplot=0.12.32
+  - coverage=6.2
+  - cython=0.29.26
+  - dask=2022.1.0
+  - dask-core=2022.1.0
+  - dask-labextension=5.2.0
+  - flake8=4.0.1
+  - fortran-magic=0.7
+  - gdal=3.4.1
+  - geopandas=0.10.2
+  - geopandas-base=0.10.2
+  - geos=3.10.1
+  - geotiff=1.7.0
+  - h5netcdf=0.13.0
+  - h5py=3.6.0
+  - hdf4=4.2.15
+  - hdf5=1.12.1
+  - intake=0.6.5
+  - intake-esm=2021.8.17
+  - intake-xarray=0.5.0
+  - ipycanvas=0.10.2
+  - ipydatagrid=1.1.8
+  - ipykernel=6.7.0
+  - ipympl=0.8.6
+  - ipyparallel=8.1.0
+  - ipython=8.0.0
+  - ipython_genutils=0.2.0
+  - ipywidgets=7.6.5
+  - jupyter-book=0.12.1
+  - jupyter-repo2docker=2021.8.0
+  - jupyter-resource-usage=0.5.1
+  - jupyter-sphinx=0.3.2
+  - jupyter_bokeh=3.0.4
+  - jupyterlab=3.2.8
+  - jupyterlab-drawio=0.9.0
+  - jupyterlab-geojson=3.2.0
+  - jupyterlab-git=0.34.2
+  - jupyterlab-link-share==0.2.4
+  - jupyterlab-system-monitor=0.8.0
+  - jupyterlab-topbar=0.6.1
+  - jupyterlab-variableinspector=3.0.9
+  - jupyterlab_pygments=0.1.2
+  - jupyterlab_server=2.10.3
+  - jupyterlab_widgets=1.0.2
+  - jupytext=1.11.5
+  - mamba=0.19.1
+  - markdown-it-py=1.1.0
+  - markupsafe=2.0.1
+  - matplotlib=3.5.1
+  - matplotlib-inline=0.1.3
+  - mdit-py-plugins=0.2.8
+  - mock=4.0.3
+  - myst-nb=0.13.1
+  - myst-parser=0.15.2
+  - nbconvert=6.4.0
+  - nbdime=3.1.1
+  - nbformat=5.1.3
+  - nbgitpuller==1.0.2
+  - networkx=2.6.3
+  - notebook=6.4.7
+  - numba=0.55.0
+  - numpy=1.21.5
+  - pandas=1.3.5
+  - pandoc=2.17.0.1
+  - pandocfilters=1.5.0
+  - pep8=1.7.1
+  - pillow=8.4.0
+  - plotly=5.5.0
+  - pooch=1.5.2
+  - proj=8.2.1
+  - pyproj=3.3.0
+  - pytables=3.6.1
+  - pytest=6.2.5
+  - pytest-cov=3.0.0
+  - requests=2.27.1
+  - retrolab=0.3.16
+  - rise=5.7.1
+  - scikit-image=0.19.1
+  - scikit-learn=1.0.2
+  - scipy=1.7.3
+  - seaborn=0.11.2
+  - sphinx=4.4.0
+  - sphinx-jupyterbook-latex=0.4.6
+  - statsmodels=0.13.1
+  - sympy=1.9
+  - tqdm=4.62.3
+  - xarray=0.20.2
+  - xlrd=2.0.1
+
+  - pip
+  - pip:
+    - -r infra-requirements.txt
+    - -r book-requirements.txt

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -79,7 +79,6 @@ dependencies:
   - pytest-cov=3.0.0
   - requests=2.27.1
   - retrolab=0.3.16
-  - rise=5.7.1
   - scikit-image=0.19.1
   - scikit-learn=1.0.2
   - scipy=1.7.3

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -14,13 +14,10 @@ dependencies:
   - coverage=6.2
   - cython=0.29.26
   - dask=2022.1.0
-  - dask-core=2022.1.0
   - dask-labextension=5.2.0
   - flake8=4.0.1
   - fortran-magic=0.7
-  - gdal=3.4.1
   - geopandas=0.10.2
-  - geopandas-base=0.10.2
   - geos=3.10.1
   - geotiff=1.7.0
   - h5netcdf=0.13.0
@@ -36,7 +33,6 @@ dependencies:
   - ipympl=0.8.6
   - ipyparallel=8.1.0
   - ipython=8.0.0
-  - ipython_genutils=0.2.0
   - ipywidgets=7.6.5
   - jupyter-book=0.12.1
   - jupyter-repo2docker=2021.8.0
@@ -52,7 +48,6 @@ dependencies:
   - jupyterlab-topbar=0.6.1
   - jupyterlab-variableinspector=3.0.9
   - jupyterlab_pygments=0.1.2
-  - jupyterlab_server=2.10.3
   - jupyterlab_widgets=1.0.2
   - jupytext=1.11.5
   - mamba=0.19.1
@@ -67,7 +62,7 @@ dependencies:
   - nbconvert=6.4.0
   - nbdime=3.1.1
   - nbformat=5.1.3
-  - nbgitpuller==1.0.2
+  - nbgitpuller=1.0.2
   - networkx=2.6.3
   - notebook=6.4.7
   - numba=0.55.0

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -1,34 +1,9 @@
-# WARNING: Original source at scripts/infra-packages/requirements.txt
-# PLEASE DO NOT EDIT ELSEWHERE
-# After editing scripts/infra-packages/requirements.txt, please run
-# scripts/infra-packages/sync.bash.
+# A few packages not available on conda-forge. The rest of the environment is 
+# provided in environment.yml
 
-# This file pins versions of notebook related python packages we want
-# across all hubs. This makes sure we don't need to upgrade them
-# everwhere one by one.
-
-# FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
-# FIXME: Conflicts with jupyter-server-proxy somehow
-jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
-nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
-# Matches version in images/hub/Dockerfile
-jupyterhub==1.5.0
-appmode==0.8.0
-ipywidgets==7.6.3
-otter-grader==3.1.4
-jupyter-tree-download==1.0.1
-git-credential-helpers==0.2
-# Enough people like this, let's load it in.
-jupyter-contrib-nbextensions==0.5.1
-jupyter_nbextensions_configurator==0.4.1
 # Measure popularity of different packages in our hubs
 # https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
 popularity-contest==0.4.1
-# RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
-RISE==5.7.1
+
+# Assist git credentials management
+git-credential-helpers==0.2

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -1,9 +1,34 @@
-# A few packages not available on conda-forge. The rest of the environment is 
-# provided in environment.yml
+# WARNING: Original source at scripts/infra-packages/requirements.txt
+# PLEASE DO NOT EDIT ELSEWHERE
+# After editing scripts/infra-packages/requirements.txt, please run
+# scripts/infra-packages/sync.bash.
 
+# This file pins versions of notebook related python packages we want
+# across all hubs. This makes sure we don't need to upgrade them
+# everwhere one by one.
+
+# FIXME: Freeze this to get exact versions of all dependencies
+notebook==6.4.7
+# FIXME: Conflicts with jupyter-server-proxy somehow
+jupyter-client<7.0
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
+nbgitpuller==1.0.2
+jupyter-resource-usage==0.6.0
+# Matches version in images/hub/Dockerfile
+jupyterhub==1.5.0
+appmode==0.8.0
+ipywidgets==7.6.5
+otter-grader==3.1.4
+jupyter-tree-download==1.0.1
+git-credential-helpers==0.2
+# Enough people like this, let's load it in.
+jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1
 # Measure popularity of different packages in our hubs
 # https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
 popularity-contest==0.4.1
-
-# Assist git credentials management
-git-credential-helpers==0.2
+# RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
+RISE==5.7.1

--- a/deployments/stat159/image/postBuild
+++ b/deployments/stat159/image/postBuild
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-jupyter contrib nbextensions install --sys-prefix --symlink
-jupyter nbextensions_configurator enable --sys-prefix

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -8,19 +8,19 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.5
+notebook==6.4.7
 # FIXME: Conflicts with jupyter-server-proxy somehow
 jupyter-client<7.0
-jupyterlab==3.2.4
-jupyterlab-link-share==0.2.1
-nbconvert==6.1.0
-retrolab==0.3.15
+jupyterlab==3.2.8
+jupyterlab-link-share==0.2.4
+nbconvert==6.4.0
+retrolab==0.3.16
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.0
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0
-ipywidgets==7.6.3
+ipywidgets==7.6.5
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -16,7 +16,7 @@ jupyterlab-link-share==0.2.4
 nbconvert==6.4.0
 retrolab==0.3.16
 nbgitpuller==1.0.2
-jupyter-resource-usage==0.6.0
+jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==1.5.0
 appmode==0.8.0


### PR DESCRIPTION
This PR may not work as-is b/c I directly edited the requirements.txt file and
minimized it to loading only a few things not available on conda-forge.  This
is different from what the team was doing before, so it may cause issues I'm
not aware of.

@yuvipanda happy to iterate on this to make sure it works well with what you want to do with the other hubs, sorry if my changes cause any issues there. What I'm trying to do is minimize the mismatch between book usage/build, local usage and hub usage, so I can teach the students how to do basically the same thing across all three places.