### PR TITLE
Add clipboard support

### DIFF
--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -9,6 +9,10 @@ wget
 # micro  # currently not working on 18.04
 nano
 
+# Basic clipboard support
+xclip
+xsel
+
 # Basic Emacs configuration for general development.
 emacs-nox 
 python-mode 


### PR DESCRIPTION
`micro` complains its clipboard support won't work without xclip/xsel installed.