### PR TITLE
Support pushing to GitHub from stat159

### DIFF
--- a/deployments/stat159/config/common.yaml
+++ b/deployments/stat159/config/common.yaml
@@ -47,6 +47,14 @@ jupyterhub:
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
     defaultUrl: /lab
+    extraFiles:
+      gitconfig:
+        mountPath: /etc/gitconfig
+        stringData: |
+          [credential "https://github.com"]
+          helper = store --file=/tmp/github-app-git-credentials
+    extraEnv:
+      GITHUB_APP_CLIENT_ID: Iv1.28ac6d8f60ed35ac
     storage:
       type: static
       static:

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -94,3 +94,5 @@ dependencies:
   - pip
   - pip:
     - -r infra-requirements.txt
+    # For push authentication to GitHub
+    - github-app-user-auth==1.0


### PR DESCRIPTION
Deploys https://github.com/yuvipanda/github-app-user-auth to
support users pushing to GitHub securely, via
https://github.com/apps/stat159-berkeley-datahub-access

Ref https://github.com/berkeley-dsep-infra/datahub/issues/3167