### PR TITLE
Stop reporting event progress individually to users temporarily

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -139,6 +139,10 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    # Stop reporting event progress individually to users temporarily
+    # Mostly to collect data on how this affects server startup performance
+    # see https://github.com/jupyterhub/kubespawner/pull/559
+    events: false
     nodeSelector:
       hub.jupyter.org/pool-name: delta-pool
     storage:


### PR DESCRIPTION
Mostly to collect data on how this affects server startup performance
see https://github.com/jupyterhub/kubespawner/pull/559