### PR TITLE
Default data8 hub to retrolab

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -145,6 +145,7 @@ jupyterhub:
     events: false
     nodeSelector:
       hub.jupyter.org/pool-name: delta-pool
+    defaultUrl: /retro
     storage:
       type: static
       static:


### PR DESCRIPTION
data8 is using retrolab for all their work now, so switching
the default when users log in seems right.