### PR TITLE
Add more command-line tools

### DIFF
--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -3,6 +3,10 @@
 
 # Basic unix tools
 man
+man-db
+manpages-posix
+manpages-dev
+manpages-posix-dev
 
 # Download tools
 curl

--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -12,20 +12,18 @@ manpages-posix-dev
 curl
 wget
 
+# Core text editors on a *nix box: vim and emacs
+vim
+emacs-nox
+emacs-goodies-el
+python-mode
+
+
 # A couple of CLI editors that are easier than vim
 # micro  # currently not working on 18.04
 nano
 jed
 jed-extra
-
-# Basic clipboard support
-xclip
-xsel
-
-# Basic Emacs configuration for general development.
-emacs-nox 
-emacs-goodies-el
-python-mode
 
 # powerful terminal-based file manager, better than the one in JLab
 mc
@@ -42,6 +40,10 @@ texlive-plain-generic
 # Other useful document-related tools
 pandoc
 latexdiff
+
+# Basic clipboard support
+xclip
+xsel
 
 # Some useful git utilities use basic Ruby
 ruby

--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -57,6 +57,6 @@ zsh
 rsync
 tig  # console UI for git
 multitail
-browsh # text-based web browser, occasionally handy
+#browsh # text-based web browser, occasionally handy - not in 18.04
 dasel  # json/yml/csv/etc data wrangling at the terminal
 

--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -1,5 +1,5 @@
 # Some linux packages for basic terminal work, particularly
-# oriented at users new to Unix/cmd line work.
+# oriented at users new to Unix/cmd line environments.
 
 # Basic unix tools
 man

--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -24,8 +24,8 @@ xsel
 
 # Basic Emacs configuration for general development.
 emacs-nox 
-python-mode 
 emacs-goodies-el
+python-mode
 
 # powerful terminal-based file manager, better than the one in JLab
 mc

--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -47,7 +47,6 @@ latexdiff
 ruby
 
 # Other niceties for command-line work and life
-fzf   # fuzzy file finder
 pydf  # colorized disk usage
 tmux
 screen
@@ -57,6 +56,9 @@ zsh
 rsync
 tig  # console UI for git
 multitail
-#browsh # text-based web browser, occasionally handy - not in 18.04
-dasel  # json/yml/csv/etc data wrangling at the terminal
+
+# For later, these are not available in 18.04
+#browsh # text-based web browser, occasionally handy
+#dasel  # json/yml/csv/etc data wrangling at the terminal
+#fzf   # fuzzy file finder
 

--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -12,6 +12,7 @@ wget
 # micro  # currently not working on 18.04
 nano
 jed
+jed-extra
 
 # Basic clipboard support
 xclip
@@ -34,5 +35,24 @@ texlive-xetex
 texlive-fonts-recommended 
 texlive-plain-generic
 
+# Other useful document-related tools
+pandoc
+latexdiff
+
 # Some useful git utilities use basic Ruby
 ruby
+
+# Other niceties for command-line work and life
+fzf   # fuzzy file finder
+pydf  # colorized disk usage
+tmux
+screen
+htop
+nnn   # cmd line file manager
+zsh
+rsync
+tig  # console UI for git
+multitail
+browsh # text-based web browser, occasionally handy
+dasel  # json/yml/csv/etc data wrangling at the terminal
+

--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -1,5 +1,5 @@
 # Some linux packages for basic terminal work, particularly
-# oriented at newer users
+# oriented at users new to Unix/cmd line work.
 
 # Basic unix tools
 man
@@ -61,4 +61,3 @@ multitail
 #browsh # text-based web browser, occasionally handy
 #dasel  # json/yml/csv/etc data wrangling at the terminal
 #fzf   # fuzzy file finder
-


### PR DESCRIPTION
The key one here is really the man pages support, please LMK if you prefer that I separate b50ec74 from the other commit(s). The others were just me adding various tools as I think more long-term, but then I ran into this for every single command:

```
jupyter-fernando-2eperez[~]> man ls
No manual entry for ls
See 'man 7 undocumented' for help when manual pages are not available.
jupyter-fernando-2eperez[~]> man bash
No manual entry for bash
See 'man 7 undocumented' for help when manual pages are not available.
```

and I realized we need the actual _content_ of man pages, not just the `man` command :)

No big rush though, I can do without for now.

And sorry I didn't catch all these issues earlier!! Please don't think any of this is urgent - I deeply appreciate the team's work and I'm totally fine now with the setup we have. This is now polish for the long run, not a critical need.