### PR TITLE
Upgrade JLab to 3.2.9

### DIFF
--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - jupyter-repo2docker=2021.8.0
   - jupyter-resource-usage=0.6.1
   - jupyter_bokeh=3.0.4
-  - jupyterlab=3.2.8
+  - jupyterlab=3.2.9
   - jupyterlab-drawio=0.9.0
   - jupyterlab-geojson=3.2.0
   - jupyterlab-git=0.34.2


### PR DESCRIPTION
JLab 3.2.9 fixed a very annoying [console bug](https://github.com/jupyterlab/jupyterlab/issues/11466) where tab completion wasn't working at all. That made the console very unpleasant to use, so it's probably worth an upgrade when folks have a chance (not urgent though).

I tested locally and lab can be updated to 3.2.9 without changing any other packages.

Note that I don't intend to keep updating packages unless it's b/c of actual bugs we run into like this one, no worries :)