### PR TITLE
Disable RTC everywhere

### DIFF
--- a/deployments/dlab/config/common.yaml
+++ b/deployments/dlab/config/common.yaml
@@ -32,15 +32,6 @@ jupyterhub:
             # List of other admin users
 
   singleuser:
-    # Enable jupyterlab-link-share so people can share links for RTC
-    extraFiles:
-      lab-config:
-        data:
-          disabledExtensions:
-            jupyterlab-link-share: false
-    cmd:
-    - jupyterhub-singleuser
-    - --LabApp.collaborative=true
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
     storage:

--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -46,15 +46,6 @@ jupyterhub:
           - dhughes  # https://github.com/berkeley-dsep-infra/datahub/issues/2462
 
   singleuser:
-    # Enable jupyterlab-link-share so people can share links for RTC
-    extraFiles:
-      lab-config:
-        data:
-          disabledExtensions:
-            jupyterlab-link-share: false
-    cmd:
-    - jupyterhub-singleuser
-    - --LabApp.collaborative=true
     defaultUrl: /rstudio
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool

--- a/deployments/stat159/config/common.yaml
+++ b/deployments/stat159/config/common.yaml
@@ -40,10 +40,6 @@ jupyterhub:
       # The VNC /desktop link must be opened already for this to work
       DISPLAY: ":1.0"
     extraFiles:
-      lab-config:
-        data:
-          disabledExtensions:
-            jupyterlab-link-share: false
       culling-config:
         data:
           # Allow jupyterlab option to show hidden files in browser


### PR DESCRIPTION
Follow-up to https://github.com/berkeley-dsep-infra/datahub/pull/3287,
as we invesetigate wether some file corruption issues are related
to RTC or not.