### PR TITLE
Bump RAM guaranteed and allocated to 8 GB for Stat 159 hub

### DIFF
--- a/deployments/stat159/config/common.yaml
+++ b/deployments/stat159/config/common.yaml
@@ -75,8 +75,8 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     memory:
-      guarantee: 2G
-      limit: 4G
+      guarantee: 8G
+      limit: 8G
 
   custom:
     admin:


### PR DESCRIPTION
Issue: #3296