### PR TITLE
Switch to using gh-scoped-creds 2.1

### DIFF
--- a/deployments/stat159/config/common.yaml
+++ b/deployments/stat159/config/common.yaml
@@ -50,12 +50,12 @@ jupyterhub:
         mountPath: /etc/gitconfig
         stringData: |
           [credential "https://github.com"]
-          helper = store --file=/tmp/github-app-git-credentials
+          helper = store --file=/tmp/gh-scoped-creds
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
     defaultUrl: /lab
     extraEnv:
-      GITHUB_APP_CLIENT_ID: Iv1.28ac6d8f60ed35ac
+      GH_SCOPED_CREDS_CLIENT_ID: Iv1.28ac6d8f60ed35ac
     storage:
       type: static
       static:

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -97,4 +97,4 @@ dependencies:
     - -r infra-requirements.txt
     - jupyter-desktop-server
     # For push authentication to GitHub
-    - github-app-user-auth==1.1
+    - gh-scoped-creds==2.1


### PR DESCRIPTION
- Renamed in https://github.com/yuvipanda/gh-scoped-creds/pull/13
- Brings in a %ghscopedauth IPython magic contributed by @fperez
- Old command continues to work