### PR TITLE
Added gofer_nb service for staging

### DIFF
--- a/deployments/data8xv2/config/staging.yaml
+++ b/deployments/data8xv2/config/staging.yaml
@@ -8,3 +8,7 @@ jupyterhub:
     https:
       hosts:
         - hubv2-staging.data8x.berkeley.edu
+  hub:
+    services:
+      gofer_nb:
+        url: http://grader-staging.data8x.berkeley.edu:10101


### PR DESCRIPTION
The gover_nb service now points to grader-staging DNS record.