### PR TITLE
Added grader dns to data8xv2-prod

### DIFF
--- a/deployments/data8xv2/config/common.yaml
+++ b/deployments/data8xv2/config/common.yaml
@@ -20,9 +20,6 @@ jupyterhub:
     service:
       type: LoadBalancer
   hub:
-    services:
-      gofer_nb:
-        url: http://34.70.18.176:10101
     config:
       JupyterHub:
         authenticator_class: ltiauthenticator.LTIAuthenticator

--- a/deployments/data8xv2/config/prod.yaml
+++ b/deployments/data8xv2/config/prod.yaml
@@ -10,3 +10,6 @@ jupyterhub:
       pvc:
         # This also holds logs
         storage: 40Gi
+    services:
+      gofer_nb:
+        url: http://grader-prod.data8x.berkeley.edu:10101


### PR DESCRIPTION
The grader service is set to use grader-prod.data8x.berkeley.edu