### PR TITLE
Bump jupyter-syncthing-proxy version from 1.0.1 to 1.0.2

### DIFF
--- a/deployments/astro/image/infra-requirements.txt
+++ b/deployments/astro/image/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -31,4 +31,4 @@ popularity-contest==0.4.1
 # RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
 RISE==5.7.1
 # syncthing for dropbox-like functionality
-jupyter-syncthing-proxy==1.0.1
+jupyter-syncthing-proxy==1.0.2


### PR DESCRIPTION
Fixes https://github.com/berkeley-dsep-infra/datahub/issues/3241!

Fixed [here](https://github.com/yuvipanda/jupyter-syncthing-proxy/commit/f75f433b6bb637d893b2b6447133a814df0c3051) previously by @yuvipanda!

The latest release in PyPI - https://pypi.org/project/jupyter-syncthing-proxy/