### PR TITLE
Update archival policy for Datahub users

### DIFF
--- a/docs/policy/storage-retention.rst
+++ b/docs/policy/storage-retention.rst
@@ -10,8 +10,8 @@ Policy
 Criteria
 --------
 
-No non-hidden files in the user's home directory have been modified in
-the last 12 months.
+No non-hidden files in the user's home directory that have been modified in the last 6 months.
+The archival process will not happen for users who store more than 100 GB worth of data in any of our hubs. 
 
 Archival
 --------
@@ -24,22 +24,26 @@ Archival
 
 Rationale
 =========
-
-Today (6 Feb 2020), we have 18,623 home directories in datahub. Most of
-these users used datahub in previous semesters, have not logged in
+Most of our users in per course hubs who used datahub in previous semesters, have not logged in
 for a long time, and will probably never log in again. This costs us
 a lot of money in disk space - we will have to forever expand disk space.
 
-By cleaning it up after 12 months of non-usage, we will not affect any
+By cleaning it up after 6 months of non-usage, we will not affect any
 current users - just folks who haven't logged in for a long time. Archiving
 the contents would make sure people still have access to their old work,
 without leaving the burden of maintaining it forever on us.
 
+Yesterday (5 May 2022) - We found many scenarios where users stored more than 100 GB worth of data (approximated to be around ~2 TB) 
+which includes datasets in the home directories of their hubs. Most of these users did not log into their instances of the hub for the past 6 - 12 months. 
+It seems reasonable to not archive their storage data considering that their a) storage amount is large in comparision with their peers
+ and b) they have not been actively using this storage during the past 6 months.
+By following this practice, we will ensure that we are not spending unnecessarily on cloud storage costs. 
+Once identified, Users should get informed to back up their data in the next 30 days.
+Post which either the data gets deleted from their home directories or is not archived for future retrieval.
+
 Why Google Drive?
 =================
 
-For UC Berkeley users, Google Drive offers `Unlimited Free Space
-<https://bconnected.berkeley.edu/collaboration-services/google/bdrive>`_.
 We can also perform access control easily with Google Drive.
 
 Alternatives
@@ -53,4 +57,3 @@ Alternatives
    link to the users. We will need to probably clean this up every 18 months
    or so for cost reasons. This is the viable alternative, if we decide to
    not use Google Drive
-

--- a/docs/policy/storage-retention.rst
+++ b/docs/policy/storage-retention.rst
@@ -11,7 +11,6 @@ Criteria
 --------
 
 No non-hidden files in the user's home directory that have been modified in the last 6 months.
-The archival process will not happen for users who store more than 100 GB worth of data in any of our hubs. 
 
 Archival
 --------
@@ -24,7 +23,9 @@ Archival
 
 Rationale
 =========
-Most of our users in per course hubs who used datahub in previous semesters, have not logged in
+
+Today (6 Feb 2020), we have 18,623 home directories in datahub. Most of
+these users used datahub in previous semesters, have not logged in
 for a long time, and will probably never log in again. This costs us
 a lot of money in disk space - we will have to forever expand disk space.
 
@@ -32,14 +33,6 @@ By cleaning it up after 6 months of non-usage, we will not affect any
 current users - just folks who haven't logged in for a long time. Archiving
 the contents would make sure people still have access to their old work,
 without leaving the burden of maintaining it forever on us.
-
-Yesterday (5 May 2022) - We found many scenarios where users stored more than 100 GB worth of data (approximated to be around ~2 TB) 
-which includes datasets in the home directories of their hubs. Most of these users did not log into their instances of the hub for the past 6 - 12 months. 
-It seems reasonable to not archive their storage data considering that their a) storage amount is large in comparision with their peers
- and b) they have not been actively using this storage during the past 6 months.
-By following this practice, we will ensure that we are not spending unnecessarily on cloud storage costs. 
-Once identified, Users should get informed to back up their data in the next 30 days.
-Post which either the data gets deleted from their home directories or is not archived for future retrieval.
 
 Why Google Drive?
 =================


### PR DESCRIPTION
I would like to add an additional policy proposal that involves not archiving storage for users who exceed a certain storage threshold while being inactive beyond 6 months. You can read more about the rationale as part of this issue #3376

This would be an additional change to our existing archival policy document. I also updated our new archived data 
storage timeline to be around 6 months post which the data gets deleted (based on our sprint planning discussion on 5/5).

Open to all your comments to clarify the language and make a robust policy that helps communicate to our users clearly while also bringing cloud costs down.
