### PR TITLE
Temporarily stop using jupyter_server

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -104,7 +104,8 @@ jupyterhub:
     extraEnv:
       SHELL: /bin/bash
       # until https://github.com/jupyterhub/jupyterhub/pull/3918 or equivalent lands
-      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
+      # Also, with jupyter server the 'Control Panel' is not being displayed
+      JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
       PYTHON_POPCONTEST_STATSD_HOST: 'support-prometheus-statsd-exporter.support'
       PYTHON_POPCONTEST_STATSD_PORT: '9125'
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together


### PR DESCRIPTION
This brings back the Control Panel button on classic notebook,
until we figure out why that doesn't show up in jupyter server

Ref https://github.com/berkeley-dsep-infra/datahub/issues/3418#issuecomment-1143605727