### PR TITLE
Use correct name for authenticator class

### DIFF
--- a/deployments/data8x/config/common.yaml
+++ b/deployments/data8x/config/common.yaml
@@ -25,7 +25,7 @@ jupyterhub:
         url: http://35.239.20.122:10101
     config:
       JupyterHub:
-        authenticator_class: ltiauthenticator.LTI11Authenticator
+        authenticator_class: ltiauthenticator.LTIAuthenticator
       Authenticator:
         admin_users:
           # unknown, not found in any issues

--- a/deployments/data8xv2/config/common.yaml
+++ b/deployments/data8xv2/config/common.yaml
@@ -22,7 +22,7 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: ltiauthenticator.LTI11Authenticator
+        authenticator_class: ltiauthenticator.LTIAuthenticator
       Authenticator:
         admin_users:
           # unknown, not found in any issues


### PR DESCRIPTION
This alias does work, I didn't want to find the actual
fully qualified name.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/3418