### PR TITLE
Grant access:services permission to all users

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -178,6 +178,13 @@ jupyterhub:
         default_per_page: 30000
         max_per_page: 30000
       JupyterHub:
+        load_roles:
+          - name: user
+            scopes:
+            # Allow all users access to 'services', which include the hubs that
+            # use the main datahub for auth
+            - access:services
+            - self
         authenticator_class: canvasauthenticator.CanvasOAuthenticator
         # Return 424, not 503, when requests go to a stopped server
         # Keeps our 503 error graphs clearer


### PR DESCRIPTION
Without this, non-admin users weren't able to access
hubs that used the main datahub for auth.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/3418