### PR TITLE
Remove link share from all images

### DIFF
--- a/deployments/astro/image/infra-requirements.txt
+++ b/deployments/astro/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/data8xv2/image/infra-requirements.txt
+++ b/deployments/data8xv2/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/deployments/stat20/image/infra-requirements.txt
+++ b/deployments/stat20/image/infra-requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -65,11 +65,6 @@ jupyterhub:
       # is often the case. 7 seems a reasonable compromise here.
       limit: 7
     extraFiles:
-      lab-config:
-        mountPath: /etc/jupyter/labconfig/page_config.json
-        data:
-          disabledExtensions:
-            jupyterlab-link-share: true
       culling-config:
         mountPath: /etc/jupyter/jupyter_notebook_config.json
         data:

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -10,7 +10,6 @@
 # FIXME: Freeze this to get exact versions of all dependencies
 notebook==6.4.11
 jupyterlab==3.4.2
-jupyterlab-link-share==0.2.4
 retrolab==0.3.21
 nbgitpuller==1.0.2
 jupyter-resource-usage==0.6.1


### PR DESCRIPTION
Just disabling it seems to break retrolab *only* on data8xv2
for some reason?!