### PR TITLE
Pinned code-server to 4.5.1

### DIFF
--- a/deployments/data8xv2/image/environment.yml
+++ b/deployments/data8xv2/image/environment.yml
@@ -1,6 +1,3 @@
-channels:
-- conda-forge
-
 dependencies:
   - matplotlib==3.0.2
   - pandas==0.23.4
@@ -10,7 +7,6 @@ dependencies:
 
   # Visual Studio Code!
   - jupyter-vscode-proxy
-  - code-server==4.5.1
 
   - pip:
     - nbforms==0.5.1

--- a/deployments/data8xv2/image/environment.yml
+++ b/deployments/data8xv2/image/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 
   # Visual Studio Code!
   - jupyter-vscode-proxy
-  - code-server
+  - code-server==4.5.1
 
   - pip:
     - nbforms==0.5.1

--- a/deployments/data8xv2/image/environment.yml
+++ b/deployments/data8xv2/image/environment.yml
@@ -1,5 +1,7 @@
+channels:
+- conda-forge
+
 dependencies:
-  - nodejs==16.16
   - matplotlib==3.0.2
   - pandas==0.23.4
   - scipy==1.2.0

--- a/deployments/data8xv2/image/environment.yml
+++ b/deployments/data8xv2/image/environment.yml
@@ -1,4 +1,5 @@
 dependencies:
+  - nodejs==16.16
   - matplotlib==3.0.2
   - pandas==0.23.4
   - scipy==1.2.0

--- a/deployments/data8xv2/image/postBuild
+++ b/deployments/data8xv2/image/postBuild
@@ -1,11 +1,9 @@
 #!/bin/bash -l
 set -euo pipefail
 
-# Code Server needs nodejs 16+ but nodejs is pinned in 
+# Code Server needs nodejs 16+ but nodejs is pinned in
 # repo2docker working this out
-conda activate /srv/conda/envs/notebook
-conda install -c conda-forge nodejs==16.*
-conda install -c conda-forge code-server==4.5.1
+mamba install -n notebook -c conda-forge nodejs==16.* code-server>4.5
 
 # Create ipython config directory if it doesn't exist
 mkdir -p ${CONDA_DIR}/etc/ipython

--- a/deployments/data8xv2/image/postBuild
+++ b/deployments/data8xv2/image/postBuild
@@ -1,6 +1,12 @@
 #!/bin/bash -l
 set -euo pipefail
 
+# Code Server needs nodejs 16+ but nodejs is pinned in 
+# repo2docker working this out
+conda activate /srv/conda/envs/notebook
+conda install -c conda-forge nodejs==16.*
+conda install -c conda-forge code-server==4.5.1
+
 # Create ipython config directory if it doesn't exist
 mkdir -p ${CONDA_DIR}/etc/ipython
 cp ipython_config.py ${CONDA_DIR}/etc/ipython/ipython_config.py


### PR DESCRIPTION
The vscode distribution on the data8xv2 hub is installing a
two year old version of vscode. This updates vscode to May 2022 - 1.68