### PR TITLE
Bump up versions of nginx-ingress & cert-manager

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -9,8 +9,8 @@ dependencies:
    version: 6.24.1
    repository: https://grafana.github.io/helm-charts
  - name: cert-manager
-   version: v1.8.1
+   version: v1.9.1
    repository: https://charts.jetstack.io
  - name: ingress-nginx
-   version: 3.23.0
+   version: 4.2.1
    repository: https://kubernetes.github.io/ingress-nginx

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,17 +1,19 @@
 cert-manager:
   installCRDs: true
-  # Our cluster-internal DNS seems to cache aggressively in
-  # some cases. The cache is also more likely to be warm,
-  # causing issues when cert-manager tries to verify
-  # that the ACME http-01 challenge will succeed. Since
-  # Let's encrypt itself isn't going to use our cluster-local
-  # DNS, this causes false negatives - cert-manager thinks the
-  # challenge will fail, but in reality it will most likely not.
-  podDnsPolicy: None
-  podDnsConfig:
-    nameservers:
-      - 1.1.1.1
-      - 8.8.8.8
+  webhooks:
+    enabled: false
+  # # Our cluster-internal DNS seems to cache aggressively in
+  # # some cases. The cache is also more likely to be warm,
+  # # causing issues when cert-manager tries to verify
+  # # that the ACME http-01 challenge will succeed. Since
+  # # Let's encrypt itself isn't going to use our cluster-local
+  # # DNS, this causes false negatives - cert-manager thinks the
+  # # challenge will fail, but in reality it will most likely not.
+  # podDnsPolicy: None
+  # podDnsConfig:
+  #   nameservers:
+  #     - 1.1.1.1
+  #     - 8.8.8.8
 ingress-nginx:
   controller:
     config:


### PR DESCRIPTION
- Disable cert-manager validatingwebhooks for now
- Disable custom DNS servers for cert-manager too.

These two were done while investigating an outage, so should
be reverted carefully