### PR TITLE
Bump prometheus / grafana chart versions

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
  - name: prometheus-statsd-exporter
-   version: 0.3.1
+   version: 0.5.0
    repository: https://prometheus-community.github.io/helm-charts
  - name: prometheus
-   version: 11.16.9
+   version: 15.12.0
    repository: https://prometheus-community.github.io/helm-charts
  - name: grafana
-   version: 6.24.1
+   version: 6.32.11
    repository: https://grafana.github.io/helm-charts
  - name: cert-manager
    version: v1.9.1

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -70,6 +70,11 @@ prometheus:
     enabled: false
   rbac:
     create: true
+  # make sure we collect metrics on pods by app/component at least
+  kube-state-metrics:
+    metricLabelsAllowlist:
+      - pods=[app,component,hub.jupyter.org/username,app.kubernetes.io/component]
+      - nodes=[*]
   server:
     resources:
       # Without this, prometheus can easily starve users


### PR DESCRIPTION
kube-state-metrics needs to be explicitly told to collect
more labels. See https://github.com/jupyterhub/grafana-dashboards#prometheus-chart-version-14-or-newer