### PR TITLE
Updated data8xv2: remove course dropdown

### DIFF
--- a/deployments/data8xv2/image/environment.yml
+++ b/deployments/data8xv2/image/environment.yml
@@ -16,6 +16,5 @@ dependencies:
     - nbforms==0.5.1
     - datascience==0.17.0
 # For grading
-    - git+https://github.com/ucbds-infra/Gofer-Grader.git@dbf3500
-    - gofer-submit==0.4
+    - otter-submit==0.5
     - -r infra-requirements.txt


### PR DESCRIPTION
- remove the course dropdown box from the 8x gofer_submit
extension; no longer needed
- renamed gofer-submit to otter-submit mostly because could not get access
to pypi gofer-submit entry