### PR TITLE
Pinned nbconvert and nbformat

### DIFF
--- a/deployments/data8xv2/image/environment.yml
+++ b/deployments/data8xv2/image/environment.yml
@@ -1,18 +1,19 @@
 dependencies:
   - python==3.9.*
   - pip==20.2.*
-  - matplotlib==3.4.2
-  - pandas==1.3.2
-  - scipy==1.7.3
-  - numpy==1.22.3
-
+  - matplotlib==3.5.2
+  - pandas==1.4.3
+  - scipy==1.9.0
+  - numpy==1.23.1
 
   # Visual Studio Code!
   - jupyter-vscode-proxy
 
   - pip:
     - nbforms==0.5.1
-    - datascience==0.17.0
+    - nbconvert==6.5.1
+    - nbformat==5.2.0
+    - datascience==0.17.5
 # For grading
-    - otter-submit==0.5
+    - gofer-submit==0.5.1
     - -r infra-requirements.txt


### PR DESCRIPTION
After updating the datascience and matplotlib packages I ran into
problems with jupyter server proxy not loading on startup. It is still unclear to me
why these two packages needed pinning but everything(including vscode)
is working.