### PR TITLE
Disable manage_groups for now.

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -191,7 +191,7 @@ jupyterhub:
       Authenticator:
         enable_auth_state: true
         # When we turn this on for all hubs
-        manage_groups: true
+        #manage_groups: true
       KubeSpawner:
         # Make sure working directory is ${HOME}
         # hubploy has a bug where it unconditionally puts workingdir to be /srv/repo


### PR DESCRIPTION
spawing is failing with with an sql error, causing users to see 500 errors:
```
    sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE
constraint failed: groups.name
    [SQL: INSERT INTO groups (name) VALUES (?)]
    [parameters: ('canvas::1497305::student',)]
    (Background on this error at: https://sqlalche.me/e/14/gkpj)
```