### PR TITLE
Move everyone to alpha-pool temporarily

### DIFF
--- a/deployments/astro/config/common.yaml
+++ b/deployments/astro/config/common.yaml
@@ -35,7 +35,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -47,7 +47,7 @@ jupyterhub:
           subPath: _shared
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -90,7 +90,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: delta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     defaultUrl: /retro
     storage:
       type: static

--- a/deployments/dlab/config/common.yaml
+++ b/deployments/dlab/config/common.yaml
@@ -39,7 +39,7 @@ jupyterhub:
             - cvacano
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -63,7 +63,7 @@ jupyterhub:
       DISPLAY: ":1.0"
     defaultUrl: "/lab"
     nodeSelector:
-      hub.jupyter.org/pool-name: delta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -48,7 +48,7 @@ jupyterhub:
   singleuser:
     defaultUrl: /rstudio
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       # Rocker based images have 'rstudio' as user $1000
       # so let's stick to that, and use /home/${NB_USER}

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -35,7 +35,7 @@ jupyterhub:
       # The VNC /desktop link must be opened already for this to work
       DISPLAY: ":1.0"
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: static
       static:

--- a/deployments/publichealth/config/common.yaml
+++ b/deployments/publichealth/config/common.yaml
@@ -74,7 +74,7 @@ jupyterhub:
     defaultUrl: /rstudio
 
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       # Rocker based images have 'rstudio' as user $1000
       # so let's stick to that, and use /home/${NB_USER}

--- a/deployments/stat159/config/common.yaml
+++ b/deployments/stat159/config/common.yaml
@@ -47,7 +47,7 @@ jupyterhub:
           ContentsManager:
             allow_hidden: true
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     defaultUrl: /lab
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: Iv1.28ac6d8f60ed35ac

--- a/deployments/stat20/config/common.yaml
+++ b/deployments/stat20/config/common.yaml
@@ -46,7 +46,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: alpha-pool
     defaultUrl: /rstudio
     storage:
       # Rocker based images have 'rstudio' as user $1000


### PR DESCRIPTION
I've created a new node-pool for alpha-pool that is the latest
k8s version, and I'll revert this PR once old node-pools
are drained of users.