### PR TITLE
Bump some base packages

### DIFF
--- a/deployments/astro/image/infra-requirements.txt
+++ b/deployments/astro/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/biology/image/environment.yml
+++ b/deployments/biology/image/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - python=3.9.*
-- pip=20.2.*
+- pip=22.2.*
 
 # Package to allow Jupyter Notebook or JupyterLab applications in one conda env to access other kernels (e.g. qiime2)
 - nb_conda_kernels=2.3.1

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/data8xv2/image/infra-requirements.txt
+++ b/deployments/data8xv2/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -243,9 +243,6 @@ RUN /usr/local/sbin/2021-fall-phys-188-288.bash
 
 ADD ipython_config.py ${IPYTHONDIR}/ipython_config.py
 
-# install QGrid notebook extension
-RUN jupyter nbextension enable --py --sys-prefix qgrid
-
 # Temporarily install newer version of jupyterlab-link-share
 # Move this back to just installing off infra-requirements once we are a bit stable
 RUN pip install -U jupyterlab-link-share==0.2.3

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -1,6 +1,6 @@
 dependencies:
 - nodejs=15.*
-- pip=20.2.*
+- pip=22.2.*
 - python=3.9.*
 
 - syncthing==1.18.6
@@ -11,9 +11,9 @@ dependencies:
 # Base scientific packages that other conda packages we install depend on
 # We don't want to have conda packages depend on pip packages if possible
 - numpy=1.21.*
-- matplotlib=3.4.*
+- matplotlib=3.5.*
 - scipy=1.7.*
-- ipympl=0.8.*
+- ipympl=0.9.*
 - pandas=1.3.*
 - statsmodels=0.12.*
 - scikit-learn=1.1.1

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -158,7 +158,7 @@ dask==2021.8.0
 distributed==2021.8.0
 keras-applications==1.0.8
 keras-preprocessing==1.1.2
-keras==2.6.0
+keras==2.9.0
 keras-vis==0.4.1
 plotly-express==0.4.1
 cytoolz==0.11.0

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -1,6 +1,7 @@
 # data8; foundation
 datascience==0.17.0
-okpy==1.18.1
+# Until https://github.com/okpy/ok-client/pull/473 is merged
+git+https://github.com/yuvipanda/ok-client@6961d778741fe61911be4d00beff9bd8afc1edf7
 folium==0.12.1
 #
 # r

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -17,7 +17,6 @@ nose==1.3.7
 #
 # modules
 beautifulsoup4==4.9.3
-qgrid==1.3.1
 nb2pdf==0.6.2
 #
 # ls 88-3; neuro

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -106,10 +106,6 @@ getdist==1.3.1
 tensorflow-hub==0.12.0
 tensorflow-probability==0.13.0
 
-# mcb 163l, fall 2019
-pydot==1.4.2
-allensdk==2.13.*
-
 # cs16A/B, spring 2020
 lcapy==0.96
 

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -25,7 +25,7 @@ lxml==4.6.3
 tqdm==4.62.1
 mne==0.23.0
 nibabel==3.2.1
-h5py==3.3.0
+h5py==3.7.0
 numexpr==2.7.3
 openpyxl==3.0.7
 nilearn==0.8.0
@@ -47,7 +47,7 @@ corner==2.2.1
 pymdptoolbox==4.0-b3
 #
 # data-x; DL
-tensorflow==2.6.*
+tensorflow==2.9.*
 scikit-image==0.18.*
 tables==3.6.1
 opencv-python==4.5.3.56

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -170,7 +170,7 @@ sympy==1.8
 contextily==1.1.0
 
 # INDENG 142 Spring 2021 (future semesters as well) - https://github.com/berkeley-dsep-infra/datahub/issues/2314
-fancyimpute==0.6.0
+fancyimpute==0.7.0
 
 # JupyterLab pypi extensions
 jupyterlab-geojson==3.1.2

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -53,13 +53,13 @@ tables==3.7.0
 opencv-python==4.6.0.66
 
 # astr 128/256; spring 2021
-astroquery==0.4.3
-astropy==4.3.1
+astroquery==0.4.6
+astropy==5.1
 dustmaps==1.0.9
 george==0.4.0
-exoplanet==0.5.1
-torch==1.9.0
-torchvision==0.10.0
+exoplanet==0.5.2
+torch==1.12.1
+torchvision==0.13.1
 pyvo==1.1
 joblib==1.0.1
 theano-pymc==1.1.2

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -49,7 +49,7 @@ pymdptoolbox==4.0-b3
 # data-x; DL
 tensorflow==2.9.*
 scikit-image==0.18.*
-tables==3.6.1
+tables==3.7.0
 opencv-python==4.5.3.56
 
 # astr 128/256; spring 2021

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -136,7 +136,7 @@ ipycanvas==0.9.0
 PyPDF2==1.26.0
 
 # data100 scientific packages
-ray==1.5.2
+ray==1.13.*
 xlrd==2.0.1
 
 # data100 visualization

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -48,9 +48,9 @@ pymdptoolbox==4.0-b3
 #
 # data-x; DL
 tensorflow==2.9.*
-scikit-image==0.18.*
+scikit-image==0.19.*
 tables==3.7.0
-opencv-python==4.5.3.56
+opencv-python==4.6.0.66
 
 # astr 128/256; spring 2021
 astroquery==0.4.3

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -80,7 +80,7 @@ plotly==5.2.1
 mpmath==1.2.1
 # sympy==1.6.2
 chart-studio==1.1.0
-csaps==1.0.4
+csaps==1.1.0
 nbforms==0.5.1
 
 # issue #875, global 150Q/pacs 190 - fall 2019
@@ -108,13 +108,13 @@ tensorflow-probability==0.13.0
 
 # mcb 163l, fall 2019
 pydot==1.4.2
-allensdk==2.12.2
+allensdk==2.13.*
 
 # cs16A/B, spring 2020
 lcapy==0.96
 
 # EPS 256, https://github.com/berkeley-dsep-infra/datahub/issues/1775
-obspy==1.2.2
+obspy==1.3.0
 
 # ds198 mch infodemiology, fall 2020/spring 2021
 # google apis
@@ -190,7 +190,7 @@ metpy==1.1.0
 pooch==1.5.2
 
 # PS88 https://github.com/berkeley-dsep-infra/datahub/issues/2925
-linearmodels==4.24
+linearmodels==4.27
 
 # https://github.com/berkeley-dsep-infra/datahub/issues/2950
 # Needed to work with a new enough version of httplib2

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -36,7 +36,7 @@ geopandas==0.10.*
 geopy==2.2.*
 pysal==2.5.*
 rtree==0.9.*
-netcdf4==1.5.*
+netcdf4==1.6.*
 mplleaflet==0.0.5
 # phys 151;
 emcee==3.1.0

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/stat20/image/infra-requirements.txt
+++ b/deployments/stat20/image/infra-requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -8,15 +8,15 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-notebook==6.4.11
-jupyterlab==3.4.2
+notebook==6.4.12
+jupyterlab==3.4.5
 retrolab==0.3.21
 nbgitpuller==1.1.0
 jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
-jupyterhub==2.3.0
+jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==7.7.0
+ipywidgets==8.0.1
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2


### PR DESCRIPTION
Ref https://github.com/berkeley-dsep-infra/datahub/issues/3605

- We upgraded pip (we were on a 2+ year old version), and the new version is more strict
   about what versions it allows - incompatible changes not allowed anymore
- So okpy needed some version unpinning: https://github.com/okpy/ok-client/pull/473
- `allensdk` was removed, as it had too strict a pandas pin
- qgrid was removed as it was not compatible with ipywidgets anymore