### PR TITLE
Add qgrid back, stick to ipywidgets 7.x

### DIFF
--- a/deployments/astro/image/infra-requirements.txt
+++ b/deployments/astro/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -20,7 +20,7 @@ jupyterhub:
           - cpyles
           - balajialwar
           # instructors & gsis as per request from Dominic Liu(Spring 2022)
-          - kagarwal2 
+          - kagarwal2
           - parthbaokar
           - andrew.lenz
           - abadrinath
@@ -30,7 +30,7 @@ jupyterhub:
           - fgeng
           - hangxingliu
           #https://github.com/berkeley-dsep-infra/datahub/issues/3198
-          - yanlisa 
+          - yanlisa
           - hug
 #  prePuller:
 #    extraImages:

--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/data8xv2/image/infra-requirements.txt
+++ b/deployments/data8xv2/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -251,9 +251,9 @@ RUN /usr/local/sbin/2021-fall-phys-188-288.bash
 
 ADD ipython_config.py ${IPYTHONDIR}/ipython_config.py
 
-# Temporarily install newer version of jupyterlab-link-share
-# Move this back to just installing off infra-requirements once we are a bit stable
-RUN pip install -U jupyterlab-link-share==0.2.3
+# Used by MCB32, but incompatible with ipywidgets 8.x
+RUN pip install --no-cache qgrid==1.3.1
+RUN jupyter nbextension enable --py --sys-prefix qgrid
 
 EXPOSE 8888
 

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/ischool/image/infra-requirements.txt
+++ b/deployments/ischool/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/deployments/stat20/image/infra-requirements.txt
+++ b/deployments/stat20/image/infra-requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -16,7 +16,7 @@ jupyter-resource-usage==0.6.1
 # Matches version in images/hub/Dockerfile
 jupyterhub==2.3.1
 appmode==0.8.0
-ipywidgets==8.0.1
+ipywidgets==7.7.2
 otter-grader==3.1.4
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2


### PR DESCRIPTION
qgrid isn't compatible with 8.x, let's stick to 7.x for now.
@ericvd-ucb says MCB32 uses it still. Should move away soon.