### PR TITLE
Increase RAM guarantee for data100

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -55,7 +55,7 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 2G
     image: {}
 


### PR DESCRIPTION
More kernel deaths are being reported, and looking at memory usage, the beta nodes where users end up seem to have a fairly high memory use %. So users could be getting their kernels killed more frequently than in other hubs. This changes the overcommit ratio quite a bit, so kernels are killed less often