### PR TITLE
Add a theta pool for data100

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -43,7 +43,7 @@ jupyterhub:
       GH_SCOPED_CREDS_CLIENT_ID: Iv1.f79b4903c7ea2847
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/data100-berkeley-datahub-access
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: theta-pool
     storage:
       type: static
       static:

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -99,3 +99,10 @@ nodePools:
       requests:
         memory: 46786Mi
     replicas: 1
+  theta:
+    nodeSelector:
+      hub.jupyter.org/pool-name: theta-pool
+    resources:
+      requests:
+        memory: 46786Mi
+    replicas: 1


### PR DESCRIPTION
It used to be in the alpha pool with datahub, but since we use the stat159 image for it I moved it to beta pool. However, it's putting excess pressure on all the other hubs on beta pool, so am moving it to its own