### PR TITLE
Increase stat20 memory limit and guarantee.

### DIFF
--- a/deployments/stat20/config/common.yaml
+++ b/deployments/stat20/config/common.yaml
@@ -63,8 +63,8 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     memory:
-      guarantee: 512M
-      limit: 1G
+      guarantee: 1024M
+      limit: 1536M
 
   custom:
     admin:


### PR DESCRIPTION
Seeing a lot of memory use, https://grafana.datahub.berkeley.edu/d/hub-dashboard/jupyterhub-dashboard?orgId=1&var-PROMETHEUS_DS=prometheus&var-hub=stat20-prod.