### PR TITLE
Set options(HTTPUserAgent) to contain RStudio Server.

### DIFF
--- a/deployments/datahub/images/default/Rprofile.site
+++ b/deployments/datahub/images/default/Rprofile.site
@@ -7,4 +7,13 @@ options(repos = c(CRAN = "https://packagemanager.rstudio.com/all/__linux__/focal
 # If not set properly, it will just serve up source packages
 # Quite hilarious, IMO.
 # See https://docs.rstudio.com/rspm/admin/binaries.html
-options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))
+# UPDATE: see the newer setting below...
+#options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))
+
+# If install.packages() is run from an RStudio console, it downloads binaries.
+# If it is run from an RStudio terminal, from a Jupyter terminal, or from a
+# Jupyter R notebook, it downloads source. Setting the user agent to the string
+# below sets it to be binary. This may improve image build times.
+# If it works, it'd be better to dynamically set the R version as above, and
+# also the RStudio Server version if possible.
+options(HTTPUserAgent = "RStudio Server (2021.9.1.372); R (4.1.2 x86_64-pc-linux-gnu x86_64 linux-gnu)")


### PR DESCRIPTION
In testing, this causes binary packages to be installed in R sessions outside of RStudio. Hopefully this takes effect during image builds and speeds them up.