### PR TITLE
Bump up nginx-ingress replica count

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -26,7 +26,7 @@ ingress-nginx:
       proxy-send-timeout: "7200"
     # Best effort guess on resource needs
     # We overprovision a little - issues here cause a full cluster outage
-    replicaCount: 2
+    replicaCount: 3
     resources:
       limits:
         cpu: 2


### PR DESCRIPTION
Just guarding against *this* being potential issue for network slowness and users executing code. Unlikely, but am pulling out all stops temporarily to stabilize everything. Memory requests & limits have already been set appropriately