### PR TITLE
Don't set advisory lock type.

### DIFF
--- a/deployments/stat20/image/Dockerfile
+++ b/deployments/stat20/image/Dockerfile
@@ -84,6 +84,9 @@ COPY class-libs.R /tmp/class-libs.R
 COPY r-packages/2022-spring-stat-20.r /tmp/r-packages/
 RUN r /tmp/r-packages/2022-spring-stat-20.r
 
+# Configure locking behavior
+COPY file-locks /etc/rstudio/file-locks
+
 # RUN tlmgr --verify-repo=none update --self && \
 #     tlmgr --verify-repo=none install \
 # 	amsmath \

--- a/deployments/stat20/image/file-locks
+++ b/deployments/stat20/image/file-locks
@@ -1,0 +1,13 @@
+# https://docs.rstudio.com/ide/server-pro/load_balancing/configuration.html#file-locking
+
+# rocker sets this to advisory, but this might be causing NFS issues.
+# lets set it to the default (default: linkbased)
+lock-type=linkbased
+
+# we'll also reduce the frequency by 1/3
+refresh-rate=60
+timeout-interval=90
+
+# log attempts
+# enable-logging=1
+# log-file=/tmp/rstudio-locking.log


### PR DESCRIPTION
We think this might be triggering excessive NFS test_stateid ops.