### PR TITLE
Add file-locks configuration to rocker images.

### DIFF
--- a/deployments/biology/image/Dockerfile
+++ b/deployments/biology/image/Dockerfile
@@ -177,6 +177,8 @@ RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
 COPY Rprofile.site /usr/lib/R/etc/Rprofile.site
 # RStudio needs its own config
 COPY rsession.conf /etc/rstudio/rsession.conf
+# Use simpler locking strategy
+COPY file-locks /etc/rstudio/file-locks
 
 #install rsession proxy
 RUN pip install --no-cache-dir \

--- a/deployments/biology/image/file-locks
+++ b/deployments/biology/image/file-locks
@@ -1,0 +1,13 @@
+# https://docs.rstudio.com/ide/server-pro/load_balancing/configuration.html#file-locking
+
+# rocker sets this to advisory, but this might be causing NFS issues.
+# lets set it to the default (default: linkbased)
+lock-type=linkbased
+
+# we'll also reduce the frequency by 1/3
+refresh-rate=60
+timeout-interval=90
+
+# log attempts
+# enable-logging=1
+# log-file=/tmp/rstudio-locking.log

--- a/deployments/ischool/image/Dockerfile
+++ b/deployments/ischool/image/Dockerfile
@@ -73,4 +73,7 @@ RUN tlmgr repository add https://ftp.math.utah.edu/pub/tex/historic/systems/texl
 RUN tlmgr option repository https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2021/tlnet-final
 RUN tlmgr --verify-repo=none update --self
 
+# Use simpler locking strategy
+COPY file-locks /etc/rstudio/file-locks
+
 ENTRYPOINT ["tini", "--"]

--- a/deployments/ischool/image/file-locks
+++ b/deployments/ischool/image/file-locks
@@ -1,0 +1,13 @@
+# https://docs.rstudio.com/ide/server-pro/load_balancing/configuration.html#file-locking
+
+# rocker sets this to advisory, but this might be causing NFS issues.
+# lets set it to the default (default: linkbased)
+lock-type=linkbased
+
+# we'll also reduce the frequency by 1/3
+refresh-rate=60
+timeout-interval=90
+
+# log attempts
+# enable-logging=1
+# log-file=/tmp/rstudio-locking.log

--- a/deployments/publichealth/image/Dockerfile
+++ b/deployments/publichealth/image/Dockerfile
@@ -118,4 +118,7 @@ RUN tlmgr --verify-repo=none update --self && \
         geometry \
         epstopdf-pkg
 
+# Use simpler locking strategy
+COPY file-locks /etc/rstudio/file-locks
+
 ENTRYPOINT ["tini", "--"]

--- a/deployments/publichealth/image/file-locks
+++ b/deployments/publichealth/image/file-locks
@@ -1,0 +1,13 @@
+# https://docs.rstudio.com/ide/server-pro/load_balancing/configuration.html#file-locking
+
+# rocker sets this to advisory, but this might be causing NFS issues.
+# lets set it to the default (default: linkbased)
+lock-type=linkbased
+
+# we'll also reduce the frequency by 1/3
+refresh-rate=60
+timeout-interval=90
+
+# log attempts
+# enable-logging=1
+# log-file=/tmp/rstudio-locking.log


### PR DESCRIPTION
Since a single process can seemingly trigger a node to issue a lot of ops, lets configure RStudio in the rocker images to behave the same as RStudio in our other images.