### PR TITLE
Bump setup_remote_docker version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ orbs:
               # fixes a docker permission problem
               # https://support.circleci.com/hc/en-us/articles/360050934711
               # https://circleci.com/docs/2.0/building-docker-images/
-              version: 19.03.13
+              version: 20.10.17
           - save_cache:
               paths:
                 - ./venv


### PR DESCRIPTION
"Old versions of Docker when combined with a newer Docker image in rare cases may have incompatibility issues with a custom script in a run command."

"In order to avoid possible job failures, please update your config by Tuesday, Oct. 11 to use the default version of Docker in setup_remote_docker jobs."

https://discuss.circleci.com/t/default-docker-version-for-remote-docker-jobs-changing-on-september-6/45157