### PR TITLE
Make stat20 memory guarantee be 1G only

### DIFF
--- a/deployments/stat20/config/common.yaml
+++ b/deployments/stat20/config/common.yaml
@@ -63,7 +63,7 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     memory:
-      guarantee: 2048M
+      guarantee: 1024M
       limit: 2048M
 
   custom:


### PR DESCRIPTION
Most users never use more than 1G of RAM here, so let's reduce it to cut cost.

Here is usage over the last 7 days:
![image](https://user-images.githubusercontent.com/30430/196584679-5c99dbab-a42a-4cf7-bf85-ab47380252a1.png)

This will only kill users when they hit the 2G, but pack more users into same set of nodes.