### PR TITLE
Move base placeholder from theta-pool to data100-pool

### DIFF
--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -99,13 +99,21 @@ nodePools:
       requests:
         memory: 46786Mi
     replicas: 1
+  data100:
+    nodeSelector:
+      hub.jupyter.org/pool-name: data100-pool
+    resources:
+      requests:
+        # Some value slightly lower than allocatable RAM on the nodepool
+        memory: 48404844Ki
+    replicas: 1
   theta:
     nodeSelector:
       hub.jupyter.org/pool-name: theta-pool
     resources:
       requests:
         memory: 46786Mi
-    replicas: 1
+    replicas: 0
   epsilon:
     nodeSelector:
       hub.jupyter.org/pool-name: epsilon-pool


### PR DESCRIPTION
We have moved data100 to its own pool, and this makes sure there is always at least one extra node of that new pool hanging around.