### PR TITLE
Disable HistoryManager on NFS on all hubs

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -65,6 +65,12 @@ jupyterhub:
       # is often the case. 4 seems a reasonable compromise here.
       limit: 4
     extraFiles:
+      no-nfs-config:
+        mountPath: /etc/jupyter/ipython_kernel_config.json
+        data:
+          HistoryManager:
+            # We do not need to keep around history for IPython, and especially not on NFS
+            enabled: false
       culling-config:
         mountPath: /etc/jupyter/jupyter_notebook_config.json
         data:


### PR DESCRIPTION
We had a typo in how we were doing this earlier (via a config file in the image) so this was putting sqlite on NFS forever. That is bad for NFS and for sqlite, so let's kill it.