### PR TITLE
Set project correctly for a11y hub

### DIFF
--- a/deployments/a11y/hubploy.yaml
+++ b/deployments/a11y/hubploy.yaml
@@ -5,13 +5,13 @@ images:
   registry:
     provider: gcloud
     gcloud:
-      project: a11y
+      project: ucb-datahub-2018
       service_key: gcr-key.json
 
 cluster:
   provider: gcloud
   gcloud:
-    project: a11y
+    project: ucb-datahub-2018
     service_key: gke-key.json
-    cluster: a11y
+    cluster: fall-2019
     zone: us-central1


### PR DESCRIPTION
This refers to the GCloud Project, of which we only have one.