### PR TITLE
Fail more gracefully after yaml error.

### DIFF
--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 0.0.1-n5548.hc326743b
+version: 0.0.1-n5575.h213be2c6

--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 0.0.1-n5575.h213be2c6
+version: 0.0.1-n5577.h425920b9

--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 0.0.1-n5296.hdee70868
+version: 0.0.1-n5548.hc326743b

--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -59,6 +59,7 @@ def get_replica_counts(events):
                 pools_replica_config = yaml.load(ev.description)
             except:
                 logging.error(f'Error in parsing description of {_event_repr(ev)}')
+                logging.error(f'{ev.description=}')
                 continue
             if pools_replica_config is None:
                 logging.error(f'No description in event {_event_repr(ev)}')

--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -55,12 +55,14 @@ def get_replica_counts(events):
     for ev in events:
         logging.info(f'Found event {_event_repr(ev)}')
         if ev.description:
+			# initialize
+			pools_replica_config = None
             try:
                 pools_replica_config = yaml.load(ev.description)
             except:
                 logging.error(f'Error in parsing description of {_event_repr(ev)}')
                 logging.error(f'{ev.description=}')
-                continue
+                pass
             if pools_replica_config is None:
                 logging.error(f'No description in event {_event_repr(ev)}')
                 continue

--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -59,7 +59,7 @@ def get_replica_counts(events):
                 pools_replica_config = yaml.load(ev.description)
             except:
                 logging.error(f'Error in parsing description of {_event_repr(ev)}')
-                pass
+                continue
             if pools_replica_config is None:
                 logging.error(f'No description in event {_event_repr(ev)}')
                 continue

--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -55,8 +55,8 @@ def get_replica_counts(events):
     for ev in events:
         logging.info(f'Found event {_event_repr(ev)}')
         if ev.description:
-			# initialize
-			pools_replica_config = None
+            # initialize
+            pools_replica_config = None
             try:
                 pools_replica_config = yaml.load(ev.description)
             except:

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-n5574.h5c4f1fef
+version: 0.0.1-n5576.hf6caa899
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-n5261.h3c876028
+version: 0.0.1-n5574.h5c4f1fef
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-n5576.hf6caa899
+version: 0.0.1-n5578.h61ec24d1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: us-central1-docker.pkg.dev/ucb-datahub-2018/core/node-placeholder-scaler
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.1-n5576.hf6caa899"
+  tag: "0.0.1-n5578.h61ec24d1"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: us-central1-docker.pkg.dev/ucb-datahub-2018/core/node-placeholder-scaler
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.1-n4691.hff360c34"
+  tag: "0.0.1-n5574.h5c4f1fef"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: us-central1-docker.pkg.dev/ucb-datahub-2018/core/node-placeholder-scaler
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.1-n5574.h5c4f1fef"
+  tag: "0.0.1-n5576.hf6caa899"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
`pools_replica_config` is undefined after parsing errors. This is causing a crash loop right now.

```
% k  -n node-placeholder logs node-placeholder-node-placeholder-scaler-768b5f4d74-f84ns
2022-11-14 05:53:37,442 Found event Evening Cool Off 2022-11-13 20:00 PST to 2022-11-14 08:00 PST
2022-11-14 05:53:37,444 Error in parsing description of Evening Cool Off 2022-11-13 20:00 PST to 2022-11-14 08:00 PST
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/srv/scaler/__main__.py", line 5, in <module>
    main()
  File "/srv/scaler/scaler.py", line 94, in main
    replica_count_overrides = get_replica_counts(get_events(config["calendarUrl"]))
  File "/srv/scaler/scaler.py", line 63, in get_replica_counts
    if pools_replica_config is None:
UnboundLocalError: local variable 'pools_replica_config' referenced before assignment
```