### PR TITLE
Specify singleuser app in a11y.

### DIFF
--- a/deployments/a11y/config/common.yaml
+++ b/deployments/a11y/config/common.yaml
@@ -33,6 +33,9 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool
     storage:


### PR DESCRIPTION
Otherwise the legacy server fails to start.