### PR TITLE
add a timer and inject a message during slow server startup

### DIFF
--- a/deployments/a11y/config/common.yaml
+++ b/deployments/a11y/config/common.yaml
@@ -1,7 +1,7 @@
 nfsPVC:
   enabled: true
   nfs:
-    serverIP: nfsserver-01
+    serverIP: 10.114.22.74
 
 jupyterhub:
   scheduling:
@@ -41,7 +41,7 @@ jupyterhub:
     storage:
       type: static
       static:
-        pvcName: home-nfs
+        pvcName: home-nfs-v3
         subPath: "{username}"
     memory:
       guarantee: 512M

--- a/deployments/a11y/config/prod.yaml
+++ b/deployments/a11y/config/prod.yaml
@@ -1,6 +1,6 @@
 nfsPVC:
   nfs:
-    shareName: export/homedirs-other-2020-07-29/a11y/prod
+    shareName: shares/a11y/prod
 
 jupyterhub:
   ingress:

--- a/deployments/a11y/config/staging.yaml
+++ b/deployments/a11y/config/staging.yaml
@@ -1,6 +1,6 @@
 nfsPVC:
   nfs:
-    shareName: export/homedirs-other-2020-07-29/a11y/staging
+    shareName: shares/a11y/staging
 
 jupyterhub:
   scheduling:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -302,6 +302,14 @@ jupyterhub:
           """
         )
 
+        spawn_launcher_timer_frequency = Integer(
+          5,
+          config=True,
+          help="""
+          Display the patience message every 5 seconds.
+          """
+        )
+
         spawn_launcher_timer_message = Unicode(
           """
           Server launch is taking longer than expected. Please be patient!
@@ -488,7 +496,7 @@ jupyterhub:
               # patient
               # https://github.com/berkeley-dsep-infra/datahub/issues/3845
               if timer >= self.spawn_launcher_timer:
-                if timer % 10 == 0:
+                if timer % self.spawn_launcher_timer_frequency == 0:
                   # display only every 10 seconds
                   patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
                   patience_message += " Current time spent waiting: %i seconds" % timer

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -321,8 +321,6 @@ jupyterhub:
             return labels
 
           async def start(self):
-            # TODO: REMOVE BEFORE MERGING 3963 TO PROD!!!!!!!!!
-            await asyncio.sleep(45)
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})
             for attr, users in custom_memory.items():

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -258,6 +258,7 @@ jupyterhub:
         import time
         from kubespawner import KubeSpawner
         from tornado import gen
+        from traitlets import ( Int, Unicode )
         import textwrap
         import z2jh
 
@@ -293,34 +294,34 @@ jupyterhub:
           except StopIteration:
             return {}
 
-        spawn_launcher_timer = Integer(
-          60,
-          config=True,
-          help="""
-          Time in seconds to wait before injecting a 'please be patient' message to display
-          to the user.
-          """
-        )
-
-        spawn_launcher_timer_frequency = Integer(
-          5,
-          config=True,
-          help="""
-          Display the patience message every 5 seconds.
-          """
-        )
-
-        spawn_launcher_timer_message = Unicode(
-          """
-          Server launch is taking longer than expected. Please be patient!
-          """,
-          config=True,
-          help="""
-          The injected 'please be patient' message to display to the user.
-          """
-        )
-
         class CustomAttrSpawner(KubeSpawner):
+          spawn_launcher_timer = Int(
+            5,
+            config=True,
+            help="""
+            Time in seconds to wait before injecting a 'please be patient' message to display
+            to the user.
+            """
+          )
+
+          spawn_launcher_timer_frequency = Int(
+            5,
+            config=True,
+            help="""
+            Display the patience message every 5 seconds.
+            """
+          )
+
+          spawn_launcher_timer_message = Unicode(
+            """
+            Server launch is taking longer than expected. Please be patient!
+            """,
+            config=True,
+            help="""
+            The injected 'please be patient' message to display to the user.
+            """
+          )
+
           def _build_common_labels(self, extra_labels):
             labels = super()._build_common_labels(extra_labels)
             # Until https://github.com/jupyterhub/kubespawner/issues/498
@@ -329,6 +330,7 @@ jupyterhub:
             return labels
 
           async def start(self):
+            await asyncio.sleep(10)
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})
             for attr, users in custom_memory.items():

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -326,7 +326,7 @@ jupyterhub:
 
           async def start(self):
             # TODO: REMOVE BEFORE MERGING 3963 TO PROD!!!!!!!!!
-            sleep(45)
+            await asyncio.sleep(45)
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})
             for attr, users in custom_memory.items():

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -257,7 +257,6 @@ jupyterhub:
         import os
         import time
         from kubespawner import KubeSpawner
-        from time import sleep # for testing 3963 only, remove before merging
         from tornado import gen
         import textwrap
         import z2jh
@@ -295,20 +294,17 @@ jupyterhub:
             return {}
 
         spawn_launcher_timer = Integer(
-          30,
-          # 60,  #uncomment before merging 3963 to prod
+          60,
           config=True,
           help="""
-          Time to wait before injecting a 'please be patient' message to display
+          Time in seconds to wait before injecting a 'please be patient' message to display
           to the user.
           """
         )
 
         spawn_launcher_timer_message = Unicode(
           """
-          Server launch is taking longer than expected.
-          Please be patient and do not restart your server as you will be placed
-          at the end of the queue.
+          Server launch is taking longer than expected. Please be patient!
           """,
           config=True,
           help="""
@@ -490,6 +486,17 @@ jupyterhub:
               if start_future and start_future.done():
                 break_while_loop = True
 
+              # check the timer, and if we're over 60sec ask the user to be
+              # patient
+              # https://github.com/berkeley-dsep-infra/datahub/issues/3845
+              if timer >= self.spawn_launcher_timer:
+                if timer % 10 == 0:
+                  # display only every 10 seconds
+                  patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
+                  patience_message += "\nCurrent time spent waiting: %i seconds" % timer
+                  event["message"] = patience_message
+                  yield { 'message': event["message"], }
+
               events = self.events
               len_events = len(events)
               if next_event < len_events:
@@ -501,14 +508,6 @@ jupyterhub:
                   # each event gets 33% closer to 90%:
                   # 30 50 63 72 78 82 84 86 87 88 88 89
                   progress += (90 - progress) / 3
-
-                  # check the timer, and if we're over 60sec ask the user to be
-                  # patient
-                  # https://github.com/berkeley-dsep-infra/datahub/issues/3845
-                  if timer >= self.spawn_launcher_timer:
-                    patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
-                    patience_massage += "\nCurrent time spent waiting: %i seconds" % timer
-                    event["message"] += patience_message
 
                   yield {
                     'progress': int(progress),

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -254,7 +254,7 @@ jupyterhub:
       # 0x-<title> used in `values.yaml` - so config set there
       # will override config set here.
       01-custom-attr-spawner: |
-        import asyncio  # testing only, remove before final commit
+        import asyncio
         import os
         import time
         from kubespawner import KubeSpawner
@@ -297,7 +297,7 @@ jupyterhub:
 
         class CustomAttrSpawner(KubeSpawner):
           spawn_launcher_timer = Int(
-            5,  # testing only, remove before final commit (change to 60)
+            60,
             config=True,
             help="""
             Time in seconds to wait before injecting a 'please be patient' message to display
@@ -306,7 +306,7 @@ jupyterhub:
           )
 
           spawn_launcher_timer_frequency = Int(
-            1,  # testing only, remove before final commit (change to 5)
+            5,
             config=True,
             help="""
             Display the patience message every 5 seconds.
@@ -331,7 +331,6 @@ jupyterhub:
             return labels
 
           async def start(self):
-            await asyncio.sleep(10)  # testing only, remove before final commit
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})
             for attr, users in custom_memory.items():

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -503,7 +503,7 @@ jupyterhub:
                   # https://github.com/berkeley-dsep-infra/datahub/issues/3845
                   if timer >= self.spawn_launcher_timer:
                     patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
-                    patience_massage += "\nCurrent time spent waiting: %i seconds"
+                    patience_massage += "\nCurrent time spent waiting: %i seconds" % timer
                     event["message"] += patience_message
 
                   yield {

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -484,6 +484,9 @@ jupyterhub:
                   # 30 50 63 72 78 82 84 86 87 88 88 89
                   progress += (90 - progress) / 3
 
+                  # check the timer, and if we're over 60sec ask the user to be
+                  # patient
+                  # https://github.com/berkeley-dsep-infra/datahub/issues/3845
                   if timer >= self.spawn_launcher_timer:
                     patience_message = """
                       Server launch is taking longer than expected (%i seconds).

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -254,6 +254,7 @@ jupyterhub:
       # 0x-<title> used in `values.yaml` - so config set there
       # will override config set here.
       01-custom-attr-spawner: |
+        import asyncio  # testing only, remove before final commit
         import os
         import time
         from kubespawner import KubeSpawner
@@ -296,7 +297,7 @@ jupyterhub:
 
         class CustomAttrSpawner(KubeSpawner):
           spawn_launcher_timer = Int(
-            5,
+            5,  # testing only, remove before final commit (change to 60)
             config=True,
             help="""
             Time in seconds to wait before injecting a 'please be patient' message to display
@@ -305,7 +306,7 @@ jupyterhub:
           )
 
           spawn_launcher_timer_frequency = Int(
-            5,
+            1,  # testing only, remove before final commit (change to 5)
             config=True,
             help="""
             Display the patience message every 5 seconds.
@@ -330,7 +331,7 @@ jupyterhub:
             return labels
 
           async def start(self):
-            await asyncio.sleep(10)
+            await asyncio.sleep(10)  # testing only, remove before final commit
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})
             for attr, users in custom_memory.items():

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -258,6 +258,7 @@ jupyterhub:
         import time
         from kubespawner import KubeSpawner
         from tornado import gen
+        import textwrap
         import z2jh
 
         hosted_domain = 'berkeley.edu'
@@ -291,6 +292,15 @@ jupyterhub:
             )
           except StopIteration:
             return {}
+
+        spawn_launcher_timer = Integer(
+          60,
+          config=True,
+          help="""
+          Time to wait before injecting a 'please be patient' message to display
+          to the user.
+          """
+        )
 
         class CustomAttrSpawner(KubeSpawner):
           def _build_common_labels(self, extra_labels):
@@ -425,6 +435,79 @@ jupyterhub:
               self.volume_mounts += custom_admin.get('extraVolumeMounts', [])
 
             return (await super().start())
+
+          async def progress(self):
+            """
+            This function is reporting back the progress of spawning a pod until
+            self._start_future has fired.
+            This is working with events parsed by the python kubernetes client,
+            and here is the specification of events that is relevant to understand:
+              ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#event-v1-core
+
+            sknapp:  adding timer to display a message asking for patience
+            (https://github.com/berkeley-dsep-infra/datahub/issues/3845)
+            """
+            if not self.events_enabled:
+              return
+
+            self.log.debug('progress generator: %s', self.pod_name)
+            start_future = self._start_future
+            progress = 0
+            next_event = 0
+            timer = 0
+
+            break_while_loop = False
+            while True:
+              # This logic avoids a race condition. self._start() will be invoked by
+              # self.start() and almost directly set self._start_future. But,
+              # progress() will be invoked via self.start(), so what happen first?
+              # Due to this, the logic below is to avoid making an assumption that
+              # self._start_future was set before this function was called.
+              if start_future is None and self._start_future:
+                start_future = self._start_future
+
+              # Ensure we capture all events by inspecting events a final time
+              # after the start_future signal has fired, we could have been in
+              # .sleep() and missed something.
+              if start_future and start_future.done():
+                break_while_loop = True
+
+              events = self.events
+              len_events = len(events)
+              if next_event < len_events:
+                for i in range(next_event, len_events):
+                  event = events[i]
+                  # move the progress bar.
+                  # Since we don't know how many events we will get,
+                  # asymptotically approach 90% completion with each event.
+                  # each event gets 33% closer to 90%:
+                  # 30 50 63 72 78 82 84 86 87 88 88 89
+                  progress += (90 - progress) / 3
+
+                  if timer >= self.spawn_launcher_timer:
+                    patience_message = """
+                      Server launch is taking longer than expected (%i seconds).
+                      Please be patient and do not restart your server as you
+                      will be placed at the end of the queue.
+                    """ % timer
+                    event["message"] += textwrap.dedent(patience_message)
+
+                  yield {
+                    'progress': int(progress),
+                    'raw_event': event,
+                    'message': "%s [%s] %s"
+                    % (
+                       event["lastTimestamp"] or event["eventTime"],
+                       event["type"],
+                       event["message"],
+                      ),
+                    }
+                next_event = len_events
+
+              if break_while_loop:
+                break
+              time += 1
+              await asyncio.sleep(1)
 
         c.JupyterHub.spawner_class = CustomAttrSpawner
       02-popularity-contest: |

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -497,7 +497,7 @@ jupyterhub:
               # https://github.com/berkeley-dsep-infra/datahub/issues/3845
               if timer >= self.spawn_launcher_timer:
                 if timer % self.spawn_launcher_timer_frequency == 0:
-                  # display only every 10 seconds
+                  # display only every X seconds
                   patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
                   patience_message += " Current time spent waiting: %i seconds" % timer
                   yield { 'message': patience_message, }

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -503,7 +503,7 @@ jupyterhub:
                   # https://github.com/berkeley-dsep-infra/datahub/issues/3845
                   if timer >= self.spawn_launcher_timer:
                     patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
-                    patience_massage += "\nCurrent time spend waiting: %i seconds"
+                    patience_massage += "\nCurrent time spent waiting: %i seconds"
                     event["message"] += patience_message
 
                   yield {

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -520,7 +520,7 @@ jupyterhub:
 
               if break_while_loop:
                 break
-              time += 1
+              timer += 1
               await asyncio.sleep(1)
 
         c.JupyterHub.spawner_class = CustomAttrSpawner

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -444,8 +444,10 @@ jupyterhub:
             and here is the specification of events that is relevant to understand:
               ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#event-v1-core
 
-            sknapp:  adding timer to display a message asking for patience
-            (https://github.com/berkeley-dsep-infra/datahub/issues/3845)
+            most of this code is directly copied from:
+              https://github.com/jupyterhub/kubespawner/blob/main/kubespawner/spawner.py#L2326
+            adding timer to display a message asking for patience:
+              https://github.com/berkeley-dsep-infra/datahub/issues/3845
             """
             if not self.events_enabled:
               return

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -491,7 +491,7 @@ jupyterhub:
                 if timer % 10 == 0:
                   # display only every 10 seconds
                   patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
-                  patience_message += "\nCurrent time spent waiting: %i seconds" % timer
+                  patience_message += " Current time spent waiting: %i seconds" % timer
                   event["message"] = patience_message
                   yield { 'message': event["message"], }
 

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -302,6 +302,18 @@ jupyterhub:
           """
         )
 
+        spawn_launcher_timer_message = Unicode(
+          """
+          Server launch is taking longer than expected.
+          Please be patient and do not restart your server as you will be placed
+          at the end of the queue.
+          """,
+          config=True,
+          help="""
+          The injected 'please be patient' message to display to the user.
+          """
+        )
+
         class CustomAttrSpawner(KubeSpawner):
           def _build_common_labels(self, extra_labels):
             labels = super()._build_common_labels(extra_labels)
@@ -490,12 +502,9 @@ jupyterhub:
                   # patient
                   # https://github.com/berkeley-dsep-infra/datahub/issues/3845
                   if timer >= self.spawn_launcher_timer:
-                    patience_message = """
-                      Server launch is taking longer than expected (%i seconds).
-                      Please be patient and do not restart your server as you
-                      will be placed at the end of the queue.
-                    """ % timer
-                    event["message"] += textwrap.dedent(patience_message)
+                    patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
+                    patience_massage += "\nCurrent time spend waiting: %i seconds"
+                    event["message"] += patience_message
 
                   yield {
                     'progress': int(progress),

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -500,8 +500,7 @@ jupyterhub:
                   # display only every 10 seconds
                   patience_message = textwrap.dedent(self.spawn_launcher_timer_message)
                   patience_message += " Current time spent waiting: %i seconds" % timer
-                  event["message"] = patience_message
-                  yield { 'message': event["message"], }
+                  yield { 'message': patience_message, }
 
               events = self.events
               len_events = len(events)

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -257,6 +257,7 @@ jupyterhub:
         import os
         import time
         from kubespawner import KubeSpawner
+        from time import sleep # for testing 3963 only, remove before merging
         from tornado import gen
         import textwrap
         import z2jh
@@ -294,7 +295,8 @@ jupyterhub:
             return {}
 
         spawn_launcher_timer = Integer(
-          60,
+          30,
+          # 60,  #uncomment before merging 3963 to prod
           config=True,
           help="""
           Time to wait before injecting a 'please be patient' message to display
@@ -323,6 +325,8 @@ jupyterhub:
             return labels
 
           async def start(self):
+            # TODO: REMOVE BEFORE MERGING 3963 TO PROD!!!!!!!!!
+            sleep(45)
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})
             for attr, users in custom_memory.items():


### PR DESCRIPTION
implement a timer in the progress function to inject a message imploring for patience during slow server spinup.

https://github.com/berkeley-dsep-infra/datahub/issues/3845