### PR TITLE
Pull jupyterhub 3.1.0 into a11y.

### DIFF
--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -4,94 +4,27 @@ channels:
 - conda-forge
 
 dependencies:
-- python==3.9
-#- syncthing==1.20.4
+- python==3.11
 - git
-#- altair==4.2.0
-#- beautifulsoup4==4.11.1
-#- black==22.6.0
-#- bokeh==2.4.3
-#- bqplot==0.12.34
-#- cartopy==0.21.0
 - coverage==6.4.4
-#- cython==0.29.32
-#- dask==2022.8.1
-#- dask-labextension==5.3.0
-#- fortran-magic==0.7
-#- h5netcdf==1.0.2
-#- h5py==3.7.0
-#- hdf4==4.2.15
-#- hdf5==1.12.2
-#- intake==0.6.5
-#- intake-esm==2021.8.17
-#- intake-xarray==0.6.0
-#- ipycanvas==0.12.1
-#- ipydatagrid==1.1.12
-#- ipympl==0.9.2
-#- ipyparallel==8.4.1
 - jupyter-book==0.13.1
 - jupyter-repo2docker==2022.2.0
 - jupyter-resource-usage==0.6.1
-#- jupyter_bokeh==3.0.4
-#- jupyterlab-drawio==0.9.0
-#- jupyterlab-favorites==3.0.0
-#- jupyterlab-geojson==3.2.0
-#- jupyterlab-git==0.39.0
 - jupyterlab-link-share
-#- jupyterlab-variableinspector==3.0.9
-#- jupyterlab_pygments==0.2.2
-#- jupyterlab_widgets==3.0.2
-#- jupytext==1.14.0
 - matplotlib
-#- matplotlib-inline==0.1.6
-#- mock==4.0.3
-#- nbdime==3.1.1
-#- networkx==2.8.6
-#- numba
 - numpy
-#- pandas==1.4.3
-#- pandoc==2.19.2
-#- pandocfilters==1.5.0
-#- pep8==1.7.1
-#- pillow==9.2.0
 - plotly
-#- pooch==1.6.0
-#- prettytable==3.4.1
-#- pyarrow==9.0.0
-#- pypdf2==2.10.4
 - pyopenssl==22.1.0
-#- pytables==3.7.0
-#- pytest==7.1.2
-#- pytest-cov==3.0.0
-#- pytest-notebook==0.6.1
-#- python-pdfkit==1.0.0 
 - requests==2.28.1
-#- scikit-image==0.19.3
-#- scikit-learn==1.1.2
-#- scipy==1.9.0
-#- seaborn==0.11.2
-#- sphinx-jupyterbook-latex==0.4.6
-#- sqlparse==0.4.3
-#- statsmodels==0.13.2
-#- sympy==1.10.1
-#- tqdm==4.64.0
 - urllib3==1.26.11
-#- xarray==2022.6.0
-#- xlrd==2.0.1
-#- micro==2.0.8
 - websockify
 - pip
 - pip:
   #- -r infra-requirements.txt
-  #- jupyter-desktop-server
-  # For push authentication to GitHub
-  # - gh-scoped-creds==4.1
   # Upgrade separate from what everyone else uses for now
   # https://github.com/berkeley-dsep-infra/datahub/issues/3693
   - notebook==7.0.0a7
-  - jupyterlab==4.0.0a30
-  #- otter-grader==4.0.1
-  #- ipython-sql==0.4.1
+  - jupyterlab==4.0.0a31
   # ###
   # The items below are from infra-requirements, however lab conflicts with the alpha notebook.
   # We disable infre-requirements.txt above and manually enable some of what it provides below.
@@ -99,7 +32,7 @@ dependencies:
   - nbgitpuller==1.1.0
   - jupyter-resource-usage==0.6.1
   # Matches version in images/hub/Dockerfile
-  - jupyterhub==2.3.1
+  - jupyterhub==3.1.0
   # - appmode==0.8.0
   # - ipywidgets==7.7.2
   # - jupyter-tree-download==1.0.1

--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   #- -r infra-requirements.txt
   # Upgrade separate from what everyone else uses for now
   # https://github.com/berkeley-dsep-infra/datahub/issues/3693
-  - notebook==7.0.0a7
+  - notebook==7.0.0a9
   - jupyterlab==4.0.0a31
   # ###
   # The items below are from infra-requirements, however lab conflicts with the alpha notebook.

--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -4,11 +4,11 @@ channels:
 - conda-forge
 
 dependencies:
-- python==3.11
+- python==3.10
 - git
 - coverage==6.4.4
 - jupyter-book==0.13.1
-- jupyter-repo2docker==2022.2.0
+- jupyter-repo2docker==2022.10.0
 - jupyter-resource-usage==0.6.1
 - jupyterlab-link-share
 - matplotlib

--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -4,12 +4,9 @@ channels:
 - conda-forge
 
 dependencies:
-- python==3.10
 - git
 - coverage==6.4.4
-- jupyter-book==0.13.1
 - jupyter-repo2docker==2022.10.0
-- jupyter-resource-usage==0.6.1
 - jupyterlab-link-share
 - matplotlib
 - numpy
@@ -23,14 +20,14 @@ dependencies:
   #- -r infra-requirements.txt
   # Upgrade separate from what everyone else uses for now
   # https://github.com/berkeley-dsep-infra/datahub/issues/3693
-  - notebook==7.0.0a9
-  - jupyterlab==4.0.0a31
+  - notebook==7.0.0a7
+  - jupyterlab==4.0.0a30
   # ###
   # The items below are from infra-requirements, however lab conflicts with the alpha notebook.
   # We disable infre-requirements.txt above and manually enable some of what it provides below.
   # ###
-  - nbgitpuller==1.1.0
-  - jupyter-resource-usage==0.6.1
+  - nbgitpuller
+  #- jupyter-resource-usage==0.6.1
   # Matches version in images/hub/Dockerfile
   - jupyterhub==3.1.0
   # - appmode==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 hubploy==0.2
 pygithub
 chartpress
-git+https://github.com/jupyterhub/repo2docker.git@d688997aeec52ff1898265bccf1bbfd5a56f6a3f
+jupyterhub-repo2docker==2022.10.0
 myst-parser
 chardet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 hubploy==0.2
 pygithub
 chartpress
-jupyterhub-repo2docker==2022.10.0
+jupyter-repo2docker==2022.10.0
 myst-parser
 chardet


### PR DESCRIPTION
It doesn't source the same infra file as the others since it uses bleeding edge jupyterlab. (for a11y testing)