### PR TITLE
Sync repo2docker between build and deploy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,9 +124,6 @@ jobs:
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
 
-            # Keep same repo2docker version in build & deploy jobs
-            pip install --upgrade git+https://github.com/jupyter/repo2docker.git@968cc43a9e238916b5032edbf84e309c8d4ff35e
-
             # Can be removed once https://github.com/docker/docker-py/issues/2225 is merged and released
             pip install --upgrade git+https://github.com/docker/docker-py.git@b6f6e7270ef1acfe7398b99b575d22d0d37ae8bf
 

--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -4,6 +4,7 @@ channels:
 - conda-forge
 
 dependencies:
+- python=3.9.*
 - git
 - coverage==6.4.4
 - jupyter-repo2docker==2022.10.0


### PR DESCRIPTION
... and the other instances in singleuser images. Its inclusion in requirements.txt keeps them the same. This also pins it at something newer. We also need to explicitly set python to 3.9 in repo2docker builds, otherwise they use python 3.7. Consider bumping this in a separate PR.