### PR TITLE
Revert today's repo2docker changes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,9 @@ jobs:
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
 
+            # Keep same repo2docker version in build & deploy jobs
+            pip install --upgrade git+https://github.com/jupyter/repo2docker.git@968cc43a9e238916b5032edbf84e309c8d4ff35e
+
             # Can be removed once https://github.com/docker/docker-py/issues/2225 is merged and released
             pip install --upgrade git+https://github.com/docker/docker-py.git@b6f6e7270ef1acfe7398b99b575d22d0d37ae8bf
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 hubploy==0.2
 pygithub
 chartpress
-jupyter-repo2docker==2022.10.0
+git+https://github.com/jupyterhub/repo2docker.git@d688997aeec52ff1898265bccf1bbfd5a56f6a3f
 myst-parser
 chardet


### PR DESCRIPTION
Since the update, user servers on a11y fail with:

```
  Traceback (most recent call last):
    File "/srv/conda/envs/notebook/lib/python3.9/site-packages/traitlets/utils/importstring.py", line 32, in import_item
      pak = getattr(module, obj)
  AttributeError: module 'notebook.base.handlers' has no attribute 'IPythonHandler'
```