### PR TITLE
Upgrade Ottr version to v1.3.0, Ipykernel version to v6.19.4 in Datahub image and Otter grader to v4.2.0 in Data8 Image

### DIFF
--- a/deployments/data8/image/infra-requirements.txt
+++ b/deployments/data8/image/infra-requirements.txt
@@ -17,7 +17,7 @@ jupyter-resource-usage==0.6.1
 jupyterhub==3.1.0
 appmode==0.8.0
 ipywidgets==7.7.2
-otter-grader==3.1.4
+otter-grader==4.2.0
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -70,3 +70,6 @@ dependencies:
 # https://github.com/berkeley-dsep-infra/datahub/issues/3939 data101, fall 2022
 - dbt-postgres=1.3.0
 - dbt-bigquery=1.3.0
+
+# Econ 148, Spring 2022, https://github.com/berkeley-dsep-infra/datahub/issues/4067
+- ipykernel = 6.19.4

--- a/deployments/datahub/images/default/install.R
+++ b/deployments/datahub/images/default/install.R
@@ -6,8 +6,8 @@ install.packages("devtools")
 source("/tmp/class-libs.R")
 
 # install ottr, needs to go first issue #3216
-# install ottr, 1.1.4, issue #3403
-devtools::install_version("ottr", version = "1.1.4", repos = "https://cran.r-project.org", upgrade = "never", quiet = FALSE)
+# install ottr, 1.3.0, issue #4008
+devtools::install_version("ottr", version = "1.3.0", repos = "https://cran.r-project.org", upgrade = "never", quiet = FALSE)
 
 # dplyr package + backends
 # From https://github.com/rocker-org/rocker-versioned2/blob/b8d23396468c5dc73115cce6c5716424d80ffcb0/scripts/install_tidyverse.sh#L30


### PR DESCRIPTION
Fixes #4008  
Fixes #4067 
Fixes #4004 