### PR TITLE
Upgrade Otter grader to v4.2.0 in Datahub image

### DIFF
--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -17,7 +17,7 @@ jupyter-resource-usage==0.6.1
 jupyterhub==3.1.0
 appmode==0.8.0
 ipywidgets==7.7.2
-otter-grader==3.1.4
+otter-grader==4.2.0
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.


### PR DESCRIPTION
Fixes #4005

As per @felder's suggestion, This pull request needs to get merged to the staging branch first and then an email outreach will happen with all instructors using the datahub-announce email list. If there are no reservation expressed by instructors then the PR can get merged in the production.