### PR TITLE
Data 100: Increase memory guarantee and limit to 4GB

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -54,8 +54,8 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     memory:
-      guarantee: 512M
-      limit: 2G
+      guarantee: 4G
+      limit: 4G
     image: {}
 
   custom:


### PR DESCRIPTION
Fixes #4176

Should revert to 2 GB RAM limit on 2/10