### PR TITLE
Update JupyterLab and mystjs extension

### DIFF
--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python==3.10.8
 
-  - altair==4.2.0
+  - altair==4.2.2
   - beautifulsoup4==4.11.1
   - black==22.12.0
   - bokeh==3.0.3
@@ -29,7 +29,7 @@ dependencies:
   - ipydatagrid==1.1.14
   - ipympl==0.9.2
   - ipyparallel==8.4.1
-  - jupyter-book==0.13.1
+  - jsonschema==4.17.3
   - jupyter-repo2docker==2022.10.0
   - jupyter-resource-usage==0.7.0
   - jupyter_bokeh==3.0.5
@@ -109,3 +109,5 @@ dependencies:
     - jupyter-remote-desktop-proxy==1.0.0
     # syncthing for dropbox-like functionality
     - jupyter-syncthing-proxy==1.0.3
+    # need a version that is compatible with jsonschema >= 4
+    - git+https://github.com/executablebooks/jupyter-book@de46e27

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - jupyter-repo2docker==2022.10.0
   - jupyter-resource-usage==0.7.0
   - jupyter_bokeh==3.0.5
-  - jupyterlab==3.5.2
+  - jupyterlab==3.6.1
   - jupyterlab-drawio==0.9.0
   - jupyterlab-favorites==3.1.1
   - jupyterlab-geojson==3.3.1
@@ -100,7 +100,7 @@ dependencies:
 # Packages not available on conda-forge, installed through pip
   - pip:
     - ipython-sql==0.4.1
-    - jupyterlab_mystjs==0.1.1
+    - jupyterlab_mystjs==0.1.3
     
     # Packages needed only on the hub (mostly linux)
     # If installing this environment on a personal machine, 

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -41,6 +41,7 @@ dependencies:
   - jupyterlab-link-share==0.2.5
   - jupyterlab-variableinspector==3.0.9
   - jupyterlab_pygments==0.2.2
+  - jupyterlab_server==2.19.0
   - jupyterlab_widgets==3.0.5
   - jupytext==1.14.4
   - mamba==1.2.0


### PR DESCRIPTION
Lab 3.6.1 adds RTC support - if the package update goes smoothly, we'll test the actual RTC functionality next.

The mystjs plugin fixes some pretty critical bugs.

