### PR TITLE
Add SQLAlchemy 1.4.46 to Datahub image

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -74,9 +74,9 @@ dependencies:
 # Econ 148, Spring 2023, https://github.com/berkeley-dsep-infra/datahub/issues/4067
 - ipykernel = 6.19.4
 
+# Econ 148, Spring 2023 https://github.com/berkeley-dsep-infra/datahub/issues/4251
+- sqlalchemy==1.4.46
+
 # Econ 148, Spring 2023 https://github.com/berkeley-dsep-infra/datahub/issues/4093
 - pip:
   - pycountry-convert==0.7.2
-    
-# Econ 148, Spring 2023 https://github.com/berkeley-dsep-infra/datahub/issues/4251
-- sqlalchemy==1.4.46

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -77,3 +77,6 @@ dependencies:
 # Econ 148, Spring 2023 https://github.com/berkeley-dsep-infra/datahub/issues/4093
 - pip:
   - pycountry-convert==0.7.2
+    
+# Econ 148, Spring 2023 https://github.com/berkeley-dsep-infra/datahub/issues/4251
+- sqlalchemy==1.4.46


### PR DESCRIPTION
fixes #4251 

Need to test whether this SQLAlchemy version is compatible with the ipythonsql version.