### PR TITLE
Don't prompt for jupyterlab announcements.

### DIFF
--- a/deployments/stat159/image/overrides.json
+++ b/deployments/stat159/image/overrides.json
@@ -1,0 +1,5 @@
+{
+  "@jupyterlab/apputils-extension:notification": {
+    "fetchNews": "false"
+  }
+}

--- a/deployments/stat159/image/postBuild
+++ b/deployments/stat159/image/postBuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eux
+
+mkdir -p ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings
+cp -p overrides.json ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings


### PR DESCRIPTION
Via https://jupyterlab.readthedocs.io/en/stable/user/binder.html#override-default-settings.