### PR TITLE
Update NodeJS for better MyST support

### DIFF
--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
   - python==3.10.8
+  - nodejs=18
 
   - altair==4.2.2
   - beautifulsoup4==4.11.1
@@ -104,7 +105,7 @@ dependencies:
 # Packages not available on conda-forge, installed through pip
   - pip:
     - ipython-sql==0.4.1
-    - jupyterlab_mystjs==0.1.4
+    - jupyterlab_myst==1.0.1
     
     # Packages needed only on the hub (mostly linux)
     # If installing this environment on a personal machine, 

--- a/deployments/stat159/image/postBuild
+++ b/deployments/stat159/image/postBuild
@@ -3,3 +3,6 @@ set -eux
 
 mkdir -p ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings
 cp -p overrides.json ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings
+
+# Install the MyST CLI - https://github.com/executablebooks/mystjs
+npm install -g myst-cli


### PR DESCRIPTION
This PR updates NodeJS to v18 so we can install the MyST CLI tools, and also updates the JupyterLab plugin (which changed names and is now at v 1.0 under the `jupyterlab_myst` package, which will be its new long-term home.