### PR TITLE
Account for when groups aren't from canvas auth.

### DIFF
--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 0.0.1-n5884.h175bfc27
+version: 0.0.1-n5928.hf4cc6fd3

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -364,7 +364,9 @@ jupyterhub:
             is_student = False
             is_instructor = False
             for group in self.user.groups:
-              # group format is 'canvas::{canvas_id}::{role}'
+              # group format is sometimes 'canvas::{canvas_id}::{role}'
+              if group.name.count('::') != 2:
+                continue
               _, group_course, group_role = group.name.split('::', 2)
               if not group_course in group_profiles:
                 continue

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-n5927.h3773e667
+version: 0.0.1-n5928.hf4cc6fd3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
We have been assuming the group names will follow a specific format. For stat159 we will, at least temporarily, disabled managed group. In either case, assuming a specific group name format isn't a good idea.