### PR TITLE
Increase RAM for Prof DeLong

### DIFF
--- a/deployments/datahub/secrets/prod.yaml
+++ b/deployments/datahub/secrets/prod.yaml
@@ -48,11 +48,11 @@ jupyterhub:
             - ENC[AES256_GCM,data:L0Ey0FFLe7uel/uu6cnVCMA3tqkSkyDaxJIsV3IS17CzppPoFkXrS8mEp5FVn9oKVi+BSpbsU745EQ==,iv:tdWCyXFFop6HhvO3IeP3AjjQ10fB6WSWoGSOu4oL0po=,tag:ZZLATDzXDCzpGxrUEZtP+g==,type:comment]
             - ENC[AES256_GCM,data:2dy9dN35cLzlU7O6NgX1B2MXJF5fOcc6y7ruDYOkb1NLeEE6CXG3SWEJQg3syyCH1jnL8Q5UCa6gnwcRYZQ4ZEk+oPnasSuiS8E7ihhSVwqkhO4BrK62EdY/sKo+6Q==,iv:HynBKylI2gY2U5p2a4OxvKG6xILRtIQ6Ofk6Q0z+PI0=,tag:IzCVCpUrNaahrsrF6RDmBw==,type:comment]
             - ENC[AES256_GCM,data:i7pf32VpWBbQaNVKo1r6Al7hMUHQWpq7VgE93fqJbpm0rS9HlkTEhVy5Ho9Mogh2lZh7wVXZtCP0TqM=,iv:UzY+xK5n+tkPhkD3Er8XWMSudXOt5QDSc1LGDQsQ//I=,tag:vzzQQt0XZ2/VsCfdCuAATA==,type:comment]
-            #ENC[AES256_GCM,data:2dy9dN35cLzlU7O6NgX1B2MXJF5fOcc6y7ruDYOkb1NLeEE6CXG3SWEJQg3syyCH1jnL8Q5UCa6gnwcRYZQ4ZEk+oPnasSuiS8E7ihhSVwqkhO4BrK62EdY/sKo+6Q==,iv:HynBKylI2gY2U5p2a4OxvKG6xILRtIQ6Ofk6Q0z+PI0=,tag:IzCVCpUrNaahrsrF6RDmBw==,type:comment]
-            #ENC[AES256_GCM,data:i7pf32VpWBbQaNVKo1r6Al7hMUHQWpq7VgE93fqJbpm0rS9HlkTEhVy5Ho9Mogh2lZh7wVXZtCP0TqM=,iv:UzY+xK5n+tkPhkD3Er8XWMSudXOt5QDSc1LGDQsQ//I=,tag:vzzQQt0XZ2/VsCfdCuAATA==,type:comment]
-            #ENC[AES256_GCM,data:L0Ey0FFLe7uel/uu6cnVCMA3tqkSkyDaxJIsV3IS17CzppPoFkXrS8mEp5FVn9oKVi+BSpbsU745EQ==,iv:tdWCyXFFop6HhvO3IeP3AjjQ10fB6WSWoGSOu4oL0po=,tag:ZZLATDzXDCzpGxrUEZtP+g==,type:comment]
-            #ENC[AES256_GCM,data:2dy9dN35cLzlU7O6NgX1B2MXJF5fOcc6y7ruDYOkb1NLeEE6CXG3SWEJQg3syyCH1jnL8Q5UCa6gnwcRYZQ4ZEk+oPnasSuiS8E7ihhSVwqkhO4BrK62EdY/sKo+6Q==,iv:HynBKylI2gY2U5p2a4OxvKG6xILRtIQ6Ofk6Q0z+PI0=,tag:IzCVCpUrNaahrsrF6RDmBw==,type:comment]
-            #ENC[AES256_GCM,data:i7pf32VpWBbQaNVKo1r6Al7hMUHQWpq7VgE93fqJbpm0rS9HlkTEhVy5Ho9Mogh2lZh7wVXZtCP0TqM=,iv:UzY+xK5n+tkPhkD3Er8XWMSudXOt5QDSc1LGDQsQ//I=,tag:vzzQQt0XZ2/VsCfdCuAATA==,type:comment]
+            - ENC[AES256_GCM,data:2dy9dN35cLzlU7O6NgX1B2MXJF5fOcc6y7ruDYOkb1NLeEE6CXG3SWEJQg3syyCH1jnL8Q5UCa6gnwcRYZQ4ZEk+oPnasSuiS8E7ihhSVwqkhO4BrK62EdY/sKo+6Q==,iv:HynBKylI2gY2U5p2a4OxvKG6xILRtIQ6Ofk6Q0z+PI0=,tag:IzCVCpUrNaahrsrF6RDmBw==,type:comment]
+            - ENC[AES256_GCM,data:i7pf32VpWBbQaNVKo1r6Al7hMUHQWpq7VgE93fqJbpm0rS9HlkTEhVy5Ho9Mogh2lZh7wVXZtCP0TqM=,iv:UzY+xK5n+tkPhkD3Er8XWMSudXOt5QDSc1LGDQsQ//I=,tag:vzzQQt0XZ2/VsCfdCuAATA==,type:comment]
+            - ENC[AES256_GCM,data:L0Ey0FFLe7uel/uu6cnVCMA3tqkSkyDaxJIsV3IS17CzppPoFkXrS8mEp5FVn9oKVi+BSpbsU745EQ==,iv:tdWCyXFFop6HhvO3IeP3AjjQ10fB6WSWoGSOu4oL0po=,tag:ZZLATDzXDCzpGxrUEZtP+g==,type:comment]
+            - ENC[AES256_GCM,data:2dy9dN35cLzlU7O6NgX1B2MXJF5fOcc6y7ruDYOkb1NLeEE6CXG3SWEJQg3syyCH1jnL8Q5UCa6gnwcRYZQ4ZEk+oPnasSuiS8E7ihhSVwqkhO4BrK62EdY/sKo+6Q==,iv:HynBKylI2gY2U5p2a4OxvKG6xILRtIQ6Ofk6Q0z+PI0=,tag:IzCVCpUrNaahrsrF6RDmBw==,type:comment]
+            - ENC[AES256_GCM,data:i7pf32VpWBbQaNVKo1r6Al7hMUHQWpq7VgE93fqJbpm0rS9HlkTEhVy5Ho9Mogh2lZh7wVXZtCP0TqM=,iv:UzY+xK5n+tkPhkD3Er8XWMSudXOt5QDSc1LGDQsQ//I=,tag:vzzQQt0XZ2/VsCfdCuAATA==,type:comment]
             - name: ENC[AES256_GCM,data:vrmKlvUHit2Kme5TcNU=,iv:jN/HJaBsa1ali4lzkpYofTK2YYI114ysIp+A9UtMf7Q=,tag:yVnLGvVtO+ao/95m9nmKuw==,type:str]
               image: ENC[AES256_GCM,data:ShSADI4ik0t4SA==,iv:Gj7QIM3nNqRsboA2KscquoZRJlkzCo8ljfavxnmqCQE=,tag:Rn5OByAatGtqUgNlIBou7g==,type:str]
               workingDir: ENC[AES256_GCM,data:gPLfwEtJT0Oz,iv:LR36WXF5khb9NvYkfsmwxt990ekEJyI/mB3T9ON3KNA=,tag:lWHZ/AnLGxSrFpIAQxeoIA==,type:str]
@@ -109,6 +109,8 @@ jupyterhub:
                 - ENC[AES256_GCM,data:xVi2fBO4aUECA9w=,iv:63sLNpSSZEEEHywrZy8i32LLy7o/pxUESTFjgaO/TdM=,tag:d+LIhskRHnYSWw+w782VWw==,type:str]
                 - ENC[AES256_GCM,data:MY8uir/+hIcX4ehC9g==,iv:o4HfUau5i3xksGKZIrF49GjOfnFbst19kzjTpcVF8aw=,tag:H1Fzs8gOIw53upXAWLPmNw==,type:str]
                 - ENC[AES256_GCM,data:P8brMHQ3ruM=,iv:KLjwPJPC59D98pCaUVG7gJzoBHFuTiOTRJfW646axDY=,tag:d4Og0v0Fy/pPD2dHQ8m3sA==,type:str]
+                - ENC[AES256_GCM,data:YKgM34+jFtSo0An+UnBOFbj7fJhmJsDnpxG3dCjIDYnnxhyo0WsFY7u76xl1Wv3v,iv:p/nEPsmVZCfH/SgtHUewQ0EuV/Si5R5+DMvWsZEgm80=,tag:xHBloa8PmVqLXranrOrHqA==,type:comment]
+                - ENC[AES256_GCM,data:8mV4WRikRyw=,iv:to99P2jotuboZDf/J1X6/Ot7Mm584aKxf1EUVzyVPO8=,tag:Dl9D2C4hvi58OZzaWwEgNg==,type:str]
                 - ENC[AES256_GCM,data:nx43nrueGU36,iv:0YBgh5it6v1Tezifiz8WBUAiHuVjoiiQ9gdF5DWVTtQ=,tag:LtqYW6OpvNxbIbRd8aqm9w==,type:str]
                 - ENC[AES256_GCM,data:oJX4oTcax2oN,iv:Qt/j6Xmnz49hjiQoDEUVFVIFdsrq+1m8EFESx2Pp6fQ=,tag:izLBevrUksEy+30o2DB+yg==,type:str]
                 - ENC[AES256_GCM,data:iwjNsyOpRpYA,iv:Pj54HXTKwf1jFxM45UliTOJRUYyiOxxM5knRzs8qNmA=,tag:6ZOkqW7wltEwbyt6ZQJlgw==,type:str]
@@ -180,8 +182,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-11-04T01:11:41Z"
-    mac: ENC[AES256_GCM,data:tR9PnZ9LkJ4vk1wHPNxh3GAmWinD04MAUkIdcPRHJ5zQ8jscPPOdzoY75RDnEfAYiV9CjgWBqqZsNY9BQbMq/i+IG/oDQlgavqDbYYzeF06fuQ7LVy1yVgWid09KJUcBKVhW6XdKD9DBi6SdpP732LwUibKQRwWGQZW9QWNoVms=,iv:SVwIaGQTqNc+Z2Bl3crIA0A5NPkuwxaXucefyeLO2zQ=,tag:hFbmu9IDLxe9SlcfNQhAFQ==,type:str]
+    lastmodified: "2023-03-03T22:42:10Z"
+    mac: ENC[AES256_GCM,data:wb993z20NYDO4FNYK6+o8LPyPl10qegFrMdqrfxQHWerHF9ek6oyxfvSkfk3tLruScIS7S6w3kM8AYfWBKNzxStCmdGaNCWAfTfQ8R94HguEX7X9ymQOE/Girdj5mZGoa1/rmiS7q8m/MglWC8uLvEDJjyVXjAvSiI/6pWwSmnU=,iv:bfygyRKYm68rohQDJxporRzzey0QnkGWfqHBT16tZsA=,tag:LGbztlo7wL9DOyVSazP9tA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
From 1 to 2 GB in Datahub for running his pedagogical experiments with ChatGPT