### PR TITLE
Update infer with hot fix

### DIFF
--- a/deployments/stat20/image/r-packages/2022-spring-stat-20.r
+++ b/deployments/stat20/image/r-packages/2022-spring-stat-20.r
@@ -7,7 +7,6 @@ class_name = "2022 Spring Stat 20"
 class_libs = c(
     "fivethirtyeight", "0.6.2",
     "gapminder", "0.3.0",
-    "infer", "1.0.0",
     "janitor", "2.1.0",
     "openintro", "2.2.0",
     "pagedown", "0.16",
@@ -27,6 +26,7 @@ class_libs_install_version(class_name, class_libs)
 devtools::install_github("mdbeckman/dcData", ref="56888a6")
 devtools::install_github("hadley/emo@3f03b11")
 devtools::install_github("andrewpbray/boxofdata@8afd934")
+devtools::install_github("tidymodels/infer@2806a69")
 
 file.symlink("/opt/shared/stat20/stat20data", "/usr/local/lib/R/site-library/stat20data")
 


### PR DESCRIPTION
Swap version of infer from 1.0.0 on CRAN to a version from github that has a bug fix to rep_sample_n()