### PR TITLE
Install nbdime from git for jupyter server 2.0 compatibility

### DIFF
--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -61,7 +61,13 @@ dependencies:
   - matplotlib-inline==0.1.6
   - mock==5.0.1
   - nbconvert==6.5.3
-  - nbdime==3.1.1
+  
+  # nbdime 3.1.1 is incompatible with jupyter server 2.0
+  # See https://github.com/jupyter/nbdime/pull/649.
+  # Use manual pip install from git (see below), revert once
+  # official compatible release is available.
+  #- nbdime==3.1.1
+  
   - nbgitpuller==1.1.1
   - networkx==3.0
   - numba==0.56.4
@@ -117,7 +123,10 @@ dependencies:
     - ipython-sql==0.4.1
     - ipytest==0.13.0
     - nbval==0.10.0
-    
+    # nbdime 3.1.1 is incompatible with jupyter server 2.0
+    # See https://github.com/jupyter/nbdime/pull/649, remove once newer release available.
+    - git+https://github.com/jupyter/nbdime.git@2da614b
+
     # Packages needed only on the hub (mostly linux)
     # If installing this environment on a personal machine, 
     # comment these out


### PR DESCRIPTION
Currently available nbdime (v3.1.1) is incompatible with jupyter server 2.0. See https://github.com/jupyter/nbdime/pull/649 for more.

Will disable this and revert to an official release once a compatible one becomes available.