### PR TITLE
Add docs on specific deployments.

### DIFF
--- a/docs/admins/deployments/datahub.rst
+++ b/docs/admins/deployments/datahub.rst
@@ -1,0 +1,23 @@
+
+.. _deployments/datahub:
+
+=======
+DataHub
+=======
+
+
+datahub.berkeley.edu provides standard computing environment to many foundational courses across diverse disciplines.
+
+Image
+=====
+
+The datahub image contains both Python and R environments. A user can create jupyter notebooks utilizing either Python or R, or can run RStudio using R or Python.
+
+The image is currently not based on repo2docker.
+
+Resources
+=========
+
+A handful of courses have been granted elevated memory limits within the hub configuration.
+
+CDSS staff and a small number of instructors have been given administrative privileges.

--- a/docs/admins/deployments/index.rst
+++ b/docs/admins/deployments/index.rst
@@ -1,0 +1,9 @@
+===============
+Hub Deployments
+===============
+
+.. toctree::
+   :maxdepth: 1
+
+   datahub
+   stat159

--- a/docs/admins/deployments/stat159.rst
+++ b/docs/admins/deployments/stat159.rst
@@ -1,0 +1,56 @@
+
+.. _deployments/stat159:
+
+========
+Stat 159
+========
+
+
+stat159.datahub.berkeley.edu is a course-specific hub for Stat 159 as taught by Fernando Perez. It tends to include a lot of applications so that students can shift their local development workflows to the cloud.
+
+Image
+=====
+
+Notably the image contains support for RTC. As of March 2023, this requires:
+
+  - altair==4.2.2
+  - boken==2.4.3
+  - dask==2023.1.1
+  - jupyter_server==2.2.1
+  - jupyterlab==3.6.1
+  - jupyterlab_server==2.19.0
+  - tornado==6.2.0
+  - git+https://github.com/berkeley-dsep-infra/tmpystore.git@84765e1
+
+Some of these are hard requirements and others were necessary to make conda happy.
+
+Configuration
+=============
+
+Along with the dependencies, the singleuser server is modified to launch as
+
+```
+  singleuser:
+    cmd:
+      - jupyterhub-singleuser
+      - --LabApp.collaborative=true
+      # https://jupyterlab-realtime-collaboration.readthedocs.io/en/latest/configuration.html#configuration
+      - --YDocExtension.ystore_class=tmpystore.TmpYStore
+```
+
+This:
+
+1. Turns on collaboration.
+2. Moves some sqlite storage from home directories to /tmp/.
+
+In addition to RTC, the hub also has configuration to enable `shared accounts with impersonation <https://github.com/jupyterhub/jupyterhub/blob/main/docs/source/tutorial/collaboration-users.md>`_. There are a handful of fabricated user accounts, e.g. collab-shared-1, collab-shared-2, etc. not affiliated with any real person in bCourses. There are also corresponding JupyterHub groups, shared-1, shared-2, etc. The instructors add real students to the hub groups, and some roles and scopes logic in the hub configuration gives students access to launch jupyter servers for the collaborative user accounts. The logic is in config/common.yaml while the current group affiliations are kept private in secrets.
+
+This configuration is to encourage use of RTC, and to prevent one student from having too much access to another student's home directory. The fabricated (essentially service) accounts have initally empty home directories and exist solely to provide workspaces for the group. There is currently no archive or restore procedure in mind for these shared accounts.
+
+For now, groups are defined in either the hub configuration or in the administrative /hub/admin user interface. In order to enable group assignment in this manner, we must set `Authenticator.managed_groups` to False. Ordinarily groups are provided by CanvasAuthenticator where this setting is True.
+
+Eventually instructors will be able to define groups in bCourses so that CanvasAuthenticator can remain in charge of managing groups. This will be important for the extremely large courses. It will also be beneficial in that resource allocation can be performed more easily through group affiliations and group properties.
+
+Historical Information
+======================
+The image has been periodically shared with data100 for when Fernando has taught both. Going forward, it is probably best to keep them separate and optionally kept in sync. We don't want changes in one course to come as a surprise to the other.

--- a/docs/admins/index.rst
+++ b/docs/admins/index.rst
@@ -18,3 +18,5 @@ Contributing to DataHub
    :maxdepth: 2
 
    howto/index
+
+   deployments/index


### PR DESCRIPTION
The immediate goal was to document stat159, so datahub is essentially a placeholder.