### PR TITLE
SSL: Using SPA for LetsEncrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ to merge the change from staging branch to production. Create another PR,
 this time with the `base` set to prod and the `head` set to staging. This
 PR will trigger a similar Travis process. Test your change on production
 for good measure.
+
+## SSL: LetsEncrypt Strategy
+The Berkeley-based SPA email address, datahub-support@berkeley.edu, is the
+contact email used to create the SSL certificate for the datahub at [LetsEncrypt](https://letsencrypt.org/). The address is only used by LetsEncrypt when there is a problem renewing the certificate.
+
+The SPA email address is connected to anyone in ds-infrastructure@lists.berkeley.edu.

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -49,7 +49,7 @@ jupyterhub:
     https:
       enabled: true
       letsencrypt:
-        contactEmail: yuvipanda@berkeley.edu
+        contactEmail: datahub-support@berkeley.edu
   singleuser:
     cmd:
       # Explicitly define this, as it's no longer set by z2jh

--- a/support/templates/issuer.yaml
+++ b/support/templates/issuer.yaml
@@ -7,7 +7,7 @@ spec:
     # The ACME server URL
     server: https://acme-v02.api.letsencrypt.org/directory
     # Email address used for ACME registration
-    email: yuvipanda@gmail.com
+    email: datahub-support@berkeley.edu
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-prod


### PR DESCRIPTION
Swapped out yuvi's email address used to create a certificate with LetsEncrypt for the berkeley-based SPA email address: datahub-support@berkeley.edu