### PR TITLE
Add field name for Data retrieval request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_archival_request.yml
+++ b/.github/ISSUE_TEMPLATE/data_archival_request.yml
@@ -19,7 +19,8 @@ body:
       description: Berkeley Email Id which you used to access Datahub!
     validations:
       required: true
-  - type: textarea
+  - id: link
+    type: textarea
     attributes:
       label: Link to Datahub Folder
       description: Link to the location where your archived files are kept!

--- a/deployments/dlab/config/common.yaml
+++ b/deployments/dlab/config/common.yaml
@@ -37,6 +37,15 @@ jupyterhub:
             - klganter
             - cvacano
   singleuser:
+    cmd:
+      - jupyterhub-singleuser
+      - --LabApp.collaborative=true
+    # Enable jupyterlab-link-share so people can share links for RTC
+    extraFiles:
+      lab-config:
+        data:
+          disabledExtensions:
+            jupyterlab-link-share: false
     nodeSelector:
       hub.jupyter.org/pool-name: dlab-pool
     storage:

--- a/deployments/dlab/config/common.yaml
+++ b/deployments/dlab/config/common.yaml
@@ -40,6 +40,8 @@ jupyterhub:
     cmd:
       - jupyterhub-singleuser
       - --LabApp.collaborative=true
+      # https://jupyterlab-realtime-collaboration.readthedocs.io/en/latest/configuration.html#configuration
+      - --YDocExtension.ystore_class=tmpystore.TmpYStore
     # Enable jupyterlab-link-share so people can share links for RTC
     extraFiles:
       lab-config:

--- a/deployments/dlab/hubploy.yaml
+++ b/deployments/dlab/hubploy.yaml
@@ -1,7 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/primary-user-image
-      path: ../datahub/images/default
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/dlab-user-image
   registry:
     provider: gcloud
     gcloud:

--- a/deployments/dlab/image/apt.txt
+++ b/deployments/dlab/image/apt.txt
@@ -1,0 +1,92 @@
+# Some linux packages for basic terminal work, particularly
+# oriented at users new to Unix/cmd line environments.
+
+# Basic unix tools
+man
+man-db
+manpages-posix
+manpages-dev
+manpages-posix-dev
+
+# Download/compression tools
+curl
+wget
+zip
+
+# Core text editors on a *nix box: vim and emacs
+vim
+emacs-nox
+emacs-goodies-el
+python-mode
+
+# A couple of CLI editors that are easier than vim
+# micro  # currently not working on 18.04
+nano
+jed
+jed-extra
+
+# powerful terminal-based file manager, better than the one in JLab
+mc
+
+# for easily managing multiple repositories with one command (perl-doc
+# is needed for its help pages to work)
+mr
+perl-doc
+
+# Regular build tools for compiling common stuff
+build-essential
+gfortran
+
+# Dependencies for nbconvert
+texlive-xetex
+texlive-fonts-recommended
+texlive-plain-generic
+# https://github.com/berkeley-dsep-infra/datahub/issues/3719
+texlive-lang-chinese
+lmodern
+
+# Other useful document-related tools
+pandoc
+latexdiff
+
+# Some useful git utilities use basic Ruby
+ruby
+
+# Other niceties for command-line work and life
+ack   # powerful grep-like tool
+pydf  # colorized disk usage
+tmux
+screen
+htop
+nnn   # cmd line file manager
+zsh
+rsync
+tig  # console UI for git
+multitail
+
+# For later, these are not available in 18.04
+#browsh # text-based web browser, occasionally handy
+#dasel  # json/yml/csv/etc data wrangling at the terminal
+#fzf   # fuzzy file finder
+
+## This section adds tools for desktop environment usage
+dbus-x11
+xorg
+xubuntu-icon-theme
+xfce4
+xfce4-goodies
+xclip
+xsel
+firefox
+chromium-browser
+
+# GUI text editors
+emacs
+vim-gtk3
+gedit
+
+# Git clients and tools
+git-gui
+gitg
+qgit
+meld

--- a/deployments/dlab/image/environment.yml
+++ b/deployments/dlab/image/environment.yml
@@ -1,0 +1,114 @@
+name: stat159-s23
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python==3.10.8
+
+  - altair==4.2.2
+  - beautifulsoup4==4.11.1
+  - black==22.12.0
+  - bokeh==2.4.3
+  - bqplot==0.12.36
+  - cartopy==0.21.1
+  - coverage==7.0.5
+  - cython==0.29.33
+  - dask==2023.1.1
+  - dask-labextension==6.0.0
+  - fortran-magic==0.7
+  - gh-scoped-creds==4.1
+  - h5netcdf==1.1.0
+  - h5py==3.7.0
+  - hdf4==4.2.15
+  - hdf5==1.12.2
+  - intake==0.6.6
+  - intake-esm==2022.9.18
+  - intake-xarray==0.6.1
+  - ipycanvas==0.13.1
+  - ipydatagrid==1.1.14
+  - ipympl==0.9.2
+  - ipyparallel==8.4.1
+  - jupyter-book==0.13.2
+  - jupyter-repo2docker==2022.10.0
+  - jupyter-resource-usage==0.7.1
+  - jupyter_bokeh==3.0.5
+  - jupyter_server==2.2.1
+  - jupyterlab==3.6.1
+  - jupyterlab-drawio==0.9.0
+  - jupyterlab-favorites==3.1.1
+  - jupyterlab-geojson==3.3.1
+  - jupyterlab-git==0.41.0
+  - jupyterlab-link-share==0.2.5
+  - jupyterlab-variableinspector==3.0.9
+  - jupyterlab_pygments==0.2.2
+  - jupyterlab_server==2.19.0
+  - jupyterlab_widgets==3.0.5
+  - jupytext==1.14.4
+  - mamba==1.2.0
+  - matplotlib==3.6.3
+  - matplotlib-inline==0.1.6
+  - mock==5.0.1
+  - nbconvert==6.5.3
+  - nbdime==3.1.1
+  - nbgitpuller==1.1.1
+  - networkx==3.0
+  - numba==0.56.4
+  - numpy==1.23.5
+  - pandas==1.5.3
+  - pandoc==2.19.2
+  - pandocfilters==1.5.0
+  - pep8==1.7.1
+  - pillow==9.4.0
+  - pip==22.3.1
+  - plotly==5.12.0
+  - pooch==1.6.0
+  - prettytable==3.6.0
+  - pyarrow==10.0.1
+  - pypdf2==2.11.1
+  - pytables==3.7.0
+  - pytest==7.2.1
+  - pytest-cov==4.0.0
+  - pytest-notebook==0.6.1
+  - requests==2.28.2
+  - ruyaml==0.91.0
+  - scikit-image==0.19.3
+  - scikit-learn==1.2.0
+  - scipy==1.10.0
+  - seaborn==0.12.2
+  - sphinx-jupyterbook-latex==0.5.2
+  - sqlparse==0.4.3
+  - statsmodels==0.13.5
+  - sympy==1.11.1
+  - tk==8.6.12
+  - tornado==6.2.0
+  - tqdm==4.64.1
+  - xarray==2023.1.0
+  - xlrd==2.0.1
+
+  # Packages that could be installed via the system package manager
+  # (apt, homebrew, etc) but we bring them through here for better
+  # reproducibility
+  - git==2.39.1
+  - pandoc==2.19.2
+  - pandocfilters==1.5.0
+
+  # Packages needed only on the hub (mostly linux)
+  # If installing this environment on a personal machine, 
+  # comment these out (but not the pip section below)
+  - syncthing==1.23.0
+  - micro==2.0.8
+  - websockify==0.11.0
+  - python-pdfkit==1.0.0 
+
+# Packages not available on conda-forge, installed through pip
+  - pip:
+    - ipython-sql==0.4.1
+    - jupyterlab_mystjs==0.1.4
+    
+    # Packages needed only on the hub (mostly linux)
+    # If installing this environment on a personal machine, 
+    # comment these out
+    - jupyter-remote-desktop-proxy==1.0.0
+    # syncthing for dropbox-like functionality
+    - jupyter-syncthing-proxy==1.0.3

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -1,0 +1,31 @@
+# WARNING: Original source at scripts/infra-packages/requirements.txt
+# PLEASE DO NOT EDIT ELSEWHERE
+# After editing scripts/infra-packages/requirements.txt, please run
+# scripts/infra-packages/sync.bash.
+
+# This file pins versions of notebook related python packages we want
+# across all hubs. This makes sure we don't need to upgrade them
+# everwhere one by one.
+
+# FIXME: Freeze this to get exact versions of all dependencies
+notebook==6.4.12
+jupyterlab==3.4.5
+retrolab==0.3.21
+nbgitpuller==1.1.0
+jupyter-resource-usage==0.6.1
+# Matches version in images/hub/Dockerfile
+jupyterhub==3.1.0
+appmode==0.8.0
+ipywidgets==7.7.2
+jupyter-tree-download==1.0.1
+git-credential-helpers==0.2
+# Enough people like this, let's load it in.
+jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1
+# Measure popularity of different packages in our hubs
+# https://discourse.jupyter.org/t/request-for-implementation-instrument-libraries-actively-used-by-users-on-a-jupyterhub/7994?u=yuvipanda
+popularity-contest==0.4.1
+# RISE is useful for presentations - see https://github.com/berkeley-dsep-infra/datahub/issues/2527
+RISE==5.7.1
+# syncthing for dropbox-like functionality
+jupyter-syncthing-proxy==1.0.3


### PR DESCRIPTION
This change along with @felder's change [here](https://github.com/berkeley-dsep-infra/homedir-archiver/pull/5) will ensure that the link to the archived file gets pre-populated in the Github template. This avoids users copy pasting links into the template which has been error-prone.