### PR TITLE
Update Data retrieval template to have field name for "link" field

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_archival_request.yml
+++ b/.github/ISSUE_TEMPLATE/data_archival_request.yml
@@ -17,7 +17,8 @@ body:
       description: "Please enter your official UC Berkeley email address! eg: oski@berkeley.edu. Instructions on how to retrieve your files will be sent to this email address."
     validations:
       required: true
-  - type: textarea
+  - id: link
+    type: textarea
     attributes:
       label: Link to Your Datahub Folder
       description: "Please enter the link to your datahub folder. You can find the link at the bottom of the WHERE-ARE-MY-FILES.txt file in your Datahub home directory. Eg: gs://ucb-datahub-archived-homedirs/spring-2021/datahub.berkeley.edu/xxx.tar.gz"


### PR DESCRIPTION
This change along with @felder's change https://github.com/berkeley-dsep-infra/homedir-archiver/pull/5 will ensure that the link to the archived file gets pre-populated in the Github template. This avoids users copy pasting links into the template which has been error-prone.

Fixes #4397 