### PR TITLE
fail when we are unable to get the commit range in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ orbs:
                         if [ -s /tmp/commit-range-err.txt ]; then
                             echo "Unable to get commit range."
                             cat /tmp/commit-range-err.txt
+                            exit 1
                         fi
                         echo COMMIT_RANGE: ${COMMIT_RANGE}
                         echo "export COMMIT_RANGE='${COMMIT_RANGE}'" >> ${BASH_ENV}


### PR DESCRIPTION
currently, if we are unable to determine the commit range that we're testing against, the script will exit w/a retval of 0 and continue the build and fail later on.

i propose failing if there's no commit range.  :)

<img width="687" alt="image" src="https://user-images.githubusercontent.com/1606572/229863512-cb222c26-341b-400b-9ae6-a40b94963d86.png">
