### PR TITLE
explicitly ignore markdown for the configuration label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,13 +13,17 @@ dockerfile:
 
 # add labels for non-singleuser image config changes
 configuration:
-  - "!**/*.md" # exclude markdown files coz labeler be broken?
   - "!deployments/**/image/**"
   - "!deployments/**/images/**"
+  - "!**/*.md" # exclude markdown files coz labeler be broken?
+  - "!**/*.txt" # exclude txt files, unless its one of:
+  - "**/apt.txt"
+  - "**/infra-requirements.txt"
+  - "**/requirements.txt"
+  - "**/runtime.txt"
+  - "**/*.json"
   - "**/*.yml"
   - "**/*.yaml"
-  - "**/*.json"
-  - "**/requirements.txt"
 
 # catch all singleuser image config changes
 singleuser-image:
@@ -37,6 +41,11 @@ images:
 
 # add labels to docs
 documentation:
+  - "**/*.txt" # include txt files, unless its one of:
+  - "!**/apt.txt"
+  - "!**/infra-requirements.txt"
+  - "!**/requirements.txt"
+  - "!**/runtime.txt"
   - "docs/**"
   - "**/*.md"
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,7 @@ dockerfile:
 
 # add labels for non-singleuser image config changes
 configuration:
+  - "!**/*.md" # exclude markdown files coz labeler be broken?
   - "!deployments/**/image/**"
   - "!deployments/**/images/**"
   - "**/*.yml"


### PR DESCRIPTION
the `configuration` label was applied to a `.md` file, which shouldn't have happened:  https://github.com/berkeley-dsep-infra/datahub/pull/4541

this should keep that from happening again!