### PR TITLE
[DH-35] unpin pyopenssl and add .readthedocs.yaml

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 myst_parser[sphinx]
 pydata-sphinx-theme
-pyopenssl==19.0.0


### PR DESCRIPTION
a new version `urllib3` was released yesterday and they no longer support SSL < 1.1.1

```
  File "/home/docs/checkouts/readthedocs.org/user_builds/uc-berkeley-jupyterhubs/envs/4553/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/home/docs/checkouts/readthedocs.org/user_builds/uc-berkeley-jupyterhubs/envs/4553/lib/python3.7/site-packages/urllib3/__init__.py", line 39, in <module>
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168
```

this PR add support for configuring our docs builds (and using the latest supplied docker containers) via `.readthedocs.yaml`...  which is a 'new' feature but still apparently in beta(?) 