### PR TITLE
[dh-21] finally fix labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,16 +13,7 @@ dockerfile:
 
 # add labels for non-singleuser image config changes
 configuration:
-  - "!deployments/**/image/**"
-  - "!deployments/**/images/**"
-  - "!**/*.md" # exclude markdown files coz labeler be broken?
-  - "**/apt.txt"
-  - "**/infra-requirements.txt"
-  - "**/requirements.txt"
-  - "**/runtime.txt"
-  - "**/*.json"
-  - "**/*.yml"
-  - "**/*.yaml"
+  - any: ['**/apt.txt', '**/infra-requirements.txt', '**/requirements.txt', '**/runtime.txt', '**/*.json', '**/*.yml','**/*.yaml']
 
 # catch all singleuser image config changes
 singleuser-image:
@@ -40,13 +31,8 @@ images:
 
 # add labels to docs
 documentation:
-  - "**/*.txt" # include txt files, unless its one of:
-  - "!**/apt.txt"
-  - "!**/infra-requirements.txt"
-  - "!**/requirements.txt"
-  - "!**/runtime.txt"
-  - "docs/**"
-  - "**/*.md"
+  - any: ['**/*.txt', 'docs/**', '**/*.md', '!**/apt.txt', '!**/infra-requirements.txt', '!**/requirements.txt', '!**/runtime.txt']
+
 
 # add build-infra label to any .github or circleci changes
 build-infra:


### PR DESCRIPTION
from https://github.com/marketplace/actions/labeler :
```
# Add 'repo' label to any root file changes
repo:
- '*'

# Add '@domain/core' label to any change within the 'core' package
'@domain/core':
- package/core/*
- package/core/**/*

# Add 'test' label to any change to *.spec.js files within the source dir
test:
- src/**/*.spec.js

# Add 'source' label to any change to src files within the source dir EXCEPT for the docs sub-folder
source:
- any: ['src/**/*', '!src/docs/*']

# Add 'frontend` label to any change to *.js files as long as the `main.js` hasn't changed
frontend:
- any: ['src/**/*.js']
  all: ['!src/main.js']
```