### PR TITLE
Upgrade otter to v4.3.2 in Data 8 image

### DIFF
--- a/deployments/data8/image/environment.yml
+++ b/deployments/data8/image/environment.yml
@@ -24,4 +24,4 @@ dependencies:
   - folium==0.12.1
   - okpy==1.18.1
   - datascience==0.17.0
-  - otter-grader==3.3.0
+  - otter-grader==4.3.2 # Based on request from ericvd and sean.morris


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DH-42
https://github.com/ucbds-infra/otter-grader/releases/tag/v4.3.2
