### PR TITLE
Bump workshop hub's RAM to 4G

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -46,5 +46,5 @@ jupyterhub:
         subPath: "{username}"
     memory:
       # As low a guarantee as possible
-      guarantee: 128M
-      limit: 1G
+      guarantee: 4G
+      limit: 4G


### PR DESCRIPTION
https://github.com/berkeley-dsep-infra/datahub/issues/4413
https://jira-secure.berkeley.edu/browse/DH-38

Demog dept have their workshop starting on June 5th and notebooks are deployed using workshop hub!