### PR TITLE
Enable admin access for Data 8 Instructors and TAs in Data 8 Hub

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -51,3 +51,9 @@ jupyterhub:
     memory:
       guarantee: 512M
       limit: 1G
+    custom:
+      group_profiles:
+        course::1525580::enrollment_type::teacher:
+          admin: true
+        course::1525580::enrollment_type::ta:
+          admin: true


### PR DESCRIPTION
Ref: https://github.com/berkeley-dsep-infra/datahub/issues/4613
bcourses id mentioned in this comment - https://github.com/berkeley-dsep-infra/datahub/issues/4613#issuecomment-1583018711