### PR TITLE
move groups block to correct place in data8 config

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -34,6 +34,12 @@ jupyterhub:
           - gmerritt
           - rylo
           - sknapp
+    custom:
+      group_profiles:
+        course::1525580::enrollment_type::teacher:
+          admin: true
+        course::1525580::enrollment_type::ta:
+          admin: true
 
   singleuser:
     nodeSelector:
@@ -51,9 +57,3 @@ jupyterhub:
     memory:
       guarantee: 512M
       limit: 1G
-    custom:
-      group_profiles:
-        course::1525580::enrollment_type::teacher:
-          admin: true
-        course::1525580::enrollment_type::ta:
-          admin: true


### PR DESCRIPTION
this should fix https://github.com/berkeley-dsep-infra/datahub/pull/4628

deployment to data8-staging failed:  https://app.circleci.com/pipelines/github/berkeley-dsep-infra/datahub/2615/workflows/4e45045d-d901-40b5-8b74-c39438514a39/jobs/29396/parallel-runs/0/steps/0-110

@ryanlovett @gmerritt @balajialg 