### PR TITLE
Removing jupyter themes package with disappointment

### DIFF
--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -28,7 +28,6 @@ dependencies:
   # https://github.com/berkeley-dsep-infra/datahub/issues/3693
   - notebook==7.0.0rc0
   - jupyterlab==4.0.2
-  - jupyter_theme_editor==0.4.2  
   # ###
   # The items below are from infra-requirements, however lab conflicts with the
   # alpha notebook.


### PR DESCRIPTION
Realized during exploration with @ryanlovett that a) this tool changes the default theme and b) There is no option to revert to the old theme. Removing this package for this reason.

In addition, I am exploring whether the URL issue is caused by JN 7.0rc0? I want to eliminate unnecessary packages to make a claim