### PR TITLE
[DH-51] revert 4666

### DIFF
--- a/deployments/data100-jl4/image/environment.yml
+++ b/deployments/data100-jl4/image/environment.yml
@@ -46,6 +46,7 @@ dependencies:
 - matplotlib==3.7.1
 - matplotlib-inline==0.1.6
 - mock==4.0.3
+- notebook==6.5.4
 - nbclassic==1.0.0
 - nbdime==3.1.1
 - nbgitpuller==1.1.1
@@ -87,7 +88,6 @@ dependencies:
 - pip
 - pip:
   - -r infra-requirements.txt
-  - notebook==7.0.0b3
   - jupyter-desktop-server
   - gh-scoped-creds==4.1
   - otter-grader==4.0.1


### PR DESCRIPTION
got a bunch of errors after deploying to staging and trying to launch my container.  i will revert this for now and debug later.

```
Defaulted container "notebook" out of: notebook, block-cloud-metadata (init)
/srv/conda/envs/notebook/lib/python3.11/subprocess.py:1012: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/bin/jupyterhub-singleuser", line 5, in <module>
    from jupyterhub.singleuser import main
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/jupyterhub/singleuser/__init__.py", line 67, in <module>
    from .app import SingleUserNotebookApp, main
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/jupyterhub/singleuser/app.py", line 31, in <module>
    App = import_item(JUPYTERHUB_SINGLEUSER_APP)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/conda/envs/notebook/lib/python3.11/site-packages/traitlets/utils/importstring.py", line 30, in import_item
    module = __import__(package, fromlist=[obj])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'notebook.notebookapp' 
```
<img width="1240" alt="Screenshot 2023-06-21 at 6 12 00 PM" src="https://github.com/berkeley-dsep-infra/datahub/assets/1606572/e80931ec-735d-44ba-973e-4911d8537d02">

