### PR TITLE
Downgrade Lab to 4.0.1

### DIFF
--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   # Upgrade separate from what everyone else uses for now
   # https://github.com/berkeley-dsep-infra/datahub/issues/3693
   - notebook==7.0.0b4
-  - jupyterlab==4.0.2
+  - jupyterlab==4.0.1
   # ###
   # The items below are from infra-requirements, however lab conflicts with the
   # alpha notebook.


### PR DESCRIPTION
To test which version of lab breaks a11y hub and report upstream!