### PR TITLE
Update to `notebook==7.0.0rc1`

### DIFF
--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   #- -r infra-requirements.txt
   # Upgrade separate from what everyone else uses for now
   # https://github.com/berkeley-dsep-infra/datahub/issues/3693
-  - notebook==7.0.0b4
+  - notebook==7.0.0rc1
   - jupyterlab==4.0.1
   # ###
   # The items below are from infra-requirements, however lab conflicts with the


### PR DESCRIPTION
Follow-up to https://github.com/berkeley-dsep-infra/datahub/pull/4667

To see if the new release fixes the redirect issue: https://github.com/jupyter/notebook/releases/tag/v7.0.0rc1