### PR TITLE
[DH-51] comment out `jupytext` until 1.15.x is released

### DIFF
--- a/deployments/data100-jl4/image/environment.yml
+++ b/deployments/data100-jl4/image/environment.yml
@@ -42,7 +42,7 @@ dependencies:
 - jupyterlab_pygments==0.2.2
 - jupyterlab_server==2.23.0
 - jupyterlab_widgets==3.0.7
-- jupytext==1.14.0
+  # - jupytext==1.14.0
 - jupyter_server==2.6.0
 - matplotlib==3.7.1
 - matplotlib-inline==0.1.6


### PR DESCRIPTION
we will comment this out until then.

reference:
https://jupytext.readthedocs.io/en/latest/CHANGELOG.html
https://github.com/mwouts/jupytext/pull/1077