### PR TITLE
Increase Data 100 hub's RAM to 4GB

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -38,8 +38,8 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     memory:
-      guarantee: 2G
-      limit: 2G
+      guarantee: 4G
+      limit: 4G
     image: {}
 
   custom:


### PR DESCRIPTION
Ref: https://github.com/berkeley-dsep-infra/datahub/issues/4685