### PR TITLE
Apply spawner overrides from group properties.

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -339,6 +339,18 @@ jupyterhub:
             if override.get('admin', False):
               self.user.admin = override['admin']
 
+          def overrides_from_properties(self, properties, prefix='kubespawner_override.'):
+            """
+            Build kubespawner_override dictionary from group properties that
+            have a known prefix.
+            """
+            prefix_len = len(prefix)
+            overrides = {}
+            for k in properties:
+              if k.startswith(prefix):
+                overrides[k[prefix_len:]] = properties[k]
+            return overrides
+
           async def start(self):
             # delay if testing, see
             # https://github.com/berkeley-dsep-infra/datahub/issues/4237
@@ -371,6 +383,10 @@ jupyterhub:
               # under group_profiles.
               if group.name in group_profiles:
                 self.apply_override(group_profiles.get(group.name))
+              # Apply overrides from group properties. We may set these in the
+              # jupyterhub UI.
+              properties_overrides = self.overrides_from_properties(group.properties)
+              self.apply_override(properties_overrides)
 
             # custom.admin
             # This applies overrides for those who have self.user.admin set.


### PR DESCRIPTION
An admin must set group properties of the form kubespawner_override.{property}, such as kubespawner_override.mem_limit. This can be performed in /hub/admin > Manage Groups.

It will be important to make sure course staff have sufficient privileges to do what they need (stop/start servers, view server lists, etc.) while at the same time ensuring the cluster does not scale more than it needs to. In other words, we may want to create a role for course staff with fewer privileges than `admin`.