### PR TITLE
Remove unnecessary import.

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -258,7 +258,6 @@ jupyterhub:
         import os
         import time
         from kubespawner import KubeSpawner
-        from tornado import gen
         from traitlets import ( Int, Unicode )
         import textwrap
         import z2jh


### PR DESCRIPTION
This was originally needed when the start method had a coroutine decorator.