### PR TITLE
[DH-51] bump pandoc

### DIFF
--- a/deployments/data100-jl4/image/environment.yml
+++ b/deployments/data100-jl4/image/environment.yml
@@ -55,7 +55,6 @@ dependencies:
 - numba==0.57.0
 - numpy==1.24.2
 - pandas==2.0.2
-- pandoc==2.19.2
 - pandocfilters==1.5.0
 - pep8==1.7.1
 - pillow==9.2.0
@@ -101,4 +100,5 @@ dependencies:
   # - notebook==6.5.4
   - nbconvert==7.6.0
   - notebook==7.0.0rc2
+  - pandoc==3.1.5
   - pytest-notebook==0.8.1


### PR DESCRIPTION
our installed version was pretty old, and since we're having trouble w/`nbconvert`, which depends on `pandoc`, it's probably good form to upgrade!