### PR TITLE
point JL4/data100 hubs to new core pool

### DIFF
--- a/deployments/data100-jl4/config/common.yaml
+++ b/deployments/data100-jl4/config/common.yaml
@@ -4,7 +4,17 @@ nfsPVC:
     serverIP: 10.203.15.114
 
 jupyterhub:
+  scheduling:
+    userScheduler:
+      nodeSelector:
+        hub.jupyter.org/pool-name: core-pool-2023-07-11
+  proxy:
+    chp:
+      nodeSelector:
+        hub.jupyter.org/pool-name: core-pool-2023-07-11
   hub:
+    nodeSelector:
+      hub.jupyter.org/pool-name: core-pool-2023-07-11
     config:
       Authenticator:
         admin_users:


### PR DESCRIPTION
this was missing in the config, as i copied it from the data100 deployment.