### PR TITLE
memory increase for project A2

### DIFF
--- a/deployments/data100-jl4/config/common.yaml
+++ b/deployments/data100-jl4/config/common.yaml
@@ -57,8 +57,8 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     memory:
-      guarantee: 2G
-      limit: 2G
+      guarantee: 4G
+      limit: 4G
     image: {}
 
   custom:


### PR DESCRIPTION
Students need more than 2GB RAM to complete Project A2. [Here](https://github.com/berkeley-dsep-infra/datahub/issues/4752) is the issue.