### PR TITLE
remove grafana-spamming logic bomb from the calendar autoscaler

### DIFF
--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -139,12 +139,13 @@ def main():
                 # with a notation for each hub, once a minute, for perpetuity.
                 #
                 # the 'Find out what happened her' is, i assume, a breadcrumb
-                # yuvi, also leaving me to believe that this never really
-                # worked as intended.
+                # from yuvi, also leaving me to believe that this never really
+                # worked as intended. ;)
                 #
                 # 'actions_taken' could actually be useful in some way, so i
                 # plan on leaving that here (and commented out, most likely,
                 # for perpetuity).
+                #
                 # actions_taken.append(f"{pool_name} set to {replica_count}")
                 # Find out what happened her
 

--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -131,12 +131,21 @@ def main():
                 )
 
                 logging.info(proc.stdout.strip())
-                if (
-                    proc.stdout.strip()
-                    != f"deployment.apps/{pool_name}-placeholder unchanged"
-                ):
-                    # Something has changed, let's signal that
-                    actions_taken.append(f"{pool_name} set to {replica_count}")
+
+                # the prior logic here was looking for 'deployment.apps/data100-placeholder unchanged',
+                # but kubectl always returns 'deployment.apps/data100-placeholder configured'.
+                #
+                # since that logic always fails, the scaler would spam grafana
+                # with a notation for each hub, once a minute, for perpetuity.
+                #
+                # the 'Find out what happened her' is, i assume, a breadcrumb
+                # yuvi, also leaving me to believe that this never really
+                # worked as intended.
+                #
+                # 'actions_taken' could actually be useful in some way, so i
+                # plan on leaving that here (and commented out, most likely,
+                # for perpetuity).
+                # actions_taken.append(f"{pool_name} set to {replica_count}")
                 # Find out what happened her
 
         if "grafana" in config and actions_taken:

--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -137,8 +137,6 @@ def main():
                 ):
                     # Something has changed, let's signal that
                     actions_taken.append(f"{pool_name} set to {replica_count}")
-                    f.seek(0)
-                    logging.info(f"yaml passed to kubectl: {f.read()}")
                 # Find out what happened her
 
         if "grafana" in config and actions_taken:


### PR DESCRIPTION
yep, never trust STDOUT and negative logic.  we have been spamming grafana with `<number of hubs> * 60` annotations probably since for-ev-er.

right now, let's disable this.  maybe this was impacting grafana?  @ryanlovett and i poked around a few months back but never found anything there...  some (more robust) logic around things changing and annotations might be useful later down the road.

:headdesk: