### PR TITLE
[data8xv2] JupyterLab 4 and Jupyter Notebook 7

### DIFF
--- a/deployments/data8xv2/config/common.yaml
+++ b/deployments/data8xv2/config/common.yaml
@@ -28,7 +28,7 @@ jupyterhub:
         - read:users
         - list:users
         services:
-        - gofer_nb
+        - otter_grade
     config:
       JupyterHub:
         authenticator_class: ltiauthenticator.lti11.auth.LTI11Authenticator
@@ -110,3 +110,8 @@ jupyterhub:
       guarantee: 256M
       limit: 1G
     image: {}
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
+
+

--- a/deployments/data8xv2/config/prod.yaml
+++ b/deployments/data8xv2/config/prod.yaml
@@ -11,5 +11,5 @@ jupyterhub:
         # This also holds logs
         storage: 40Gi
     services:
-      gofer_nb:
+      otter_grade:
         url: http://grader-prod.data8x.berkeley.edu:10101

--- a/deployments/data8xv2/config/staging.yaml
+++ b/deployments/data8xv2/config/staging.yaml
@@ -10,5 +10,5 @@ jupyterhub:
         - hubv2-staging.data8x.berkeley.edu
   hub:
     services:
-      gofer_nb:
+      otter_grade:
         url: http://grader-staging.data8x.berkeley.edu:10101

--- a/deployments/data8xv2/hubploy.yaml
+++ b/deployments/data8xv2/hubploy.yaml
@@ -1,7 +1,7 @@
 images:
   images:
     - name: gcr.io/data8x-scratch/data8xv2-user-image
-      path: ../data8xv2/image
+      path: image/
   registry:
     provider: gcloud
     gcloud:

--- a/deployments/data8xv2/image/apt.txt
+++ b/deployments/data8xv2/image/apt.txt
@@ -1,0 +1,91 @@
+# Some linux packages for basic terminal work, particularly
+# oriented at users new to Unix/cmd line environments.
+
+# Basic unix tools
+man
+man-db
+manpages-posix
+manpages-dev
+manpages-posix-dev
+
+# Download tools
+curl
+wget
+
+# Core text editors on a *nix box: vim
+vim
+
+# A couple of CLI editors that are easier than vim
+# micro  # currently not working on 18.04
+nano
+jed
+jed-extra
+
+# powerful terminal-based file manager, better than the one in JLab
+mc
+
+# for easily managing multiple repositories with one command (perl-doc
+# is needed for its help pages to work)
+mr
+perl-doc
+
+# Regular build tools for compiling common stuff
+build-essential
+gfortran
+
+# Dependencies for nbconvert
+texlive-xetex
+texlive-fonts-recommended
+texlive-plain-generic
+# https://github.com/berkeley-dsep-infra/datahub/issues/3719
+texlive-lang-chinese
+lmodern
+
+# Other useful document-related tools
+pandoc
+latexdiff
+
+# Some useful git utilities use basic Ruby
+ruby
+
+# Other niceties for command-line work and life
+ack   # powerful grep-like tool
+pydf  # colorized disk usage
+tmux
+screen
+htop
+nnn   # cmd line file manager
+zsh
+rsync
+tig  # console UI for git
+multitail
+
+# For later, these are not available in 18.04
+#browsh # text-based web browser, occasionally handy
+#dasel  # json/yml/csv/etc data wrangling at the terminal
+#fzf   # fuzzy file finder
+
+## This section adds tools for desktop environment usage
+dbus-x11
+xorg
+xubuntu-icon-theme
+xfce4
+xfce4-goodies
+xclip
+xsel
+firefox
+chromium-browser
+
+# GUI text editors
+vim-gtk3
+gedit
+
+
+# Git clients and tools
+git-gui
+gitg
+qgit
+meld
+
+# For jupyter-tree-download. Ref: https://github.com/berkeley-dsep-infra/datahub/issues/3979			
+zip

--- a/deployments/data8xv2/image/environment.yml
+++ b/deployments/data8xv2/image/environment.yml
@@ -1,22 +1,102 @@
+name: data8xv2
+
+channels:
+- conda-forge
+
 dependencies:
-  - r-base==4.0.5
-  - r-tidyverse==1.3.2
-  - python==3.9.*
-  - pip==20.2.*
-  - matplotlib==3.5.2
-  - pandas==1.4.3
-  - scipy==1.9.0
-  - numpy==1.23.1
+- python==3.11.0
+- syncthing==1.20.4
+- git==2.39.1
+- altair==5.0.1
+- beautifulsoup4==4.11.1
+- black==22.6.0
+- bokeh==2.4.3
+- bqplot==0.12.34
+- cartopy==0.21.0
+- coverage==7.2.2
+- cython==0.29.32
+- distributed==2023.6.0
+- fortran-magic==0.7
+- h5netcdf==1.0.2
+- h5py==3.7.0
+- hdf4==4.2.15
+- hdf5==1.12.2
+- intake==0.6.5
+- intake-esm==2021.8.17
+- intake-xarray==0.6.0
+- ipycanvas==0.12.1
+- ipydatagrid==1.1.12
+- ipympl==0.9.2
+- ipyparallel==8.4.1
+- jsonschema==4.17.3
+- jupyter-book==0.15.1
+- jupyter_bokeh
+- jupyterlab==4.0.2
+- jupyterlab-favorites==3.0.0
+- jupyterlab-geojson==3.2.0
+- jupyterlab-variableinspector==3.0.9
+- jupyterlab_pygments==0.2.2
+- jupyterlab_server==2.23.0
+- jupyterlab_widgets==3.0.8
+- jupyter_server==2.7.0
+- matplotlib==3.7.1
+- matplotlib-inline==0.1.6
+- mock==4.0.3
+- nbclassic==1.0.0
+- nbdime==3.1.1
+- nbgitpuller==1.1.1
+- networkx==2.8.6
+- numba==0.57.0
+- numpy==1.24.2
+- pandas==2.0.2
+- pandoc==2.12
+- pandocfilters==1.5.0
+- pep8==1.7.1
+- pillow==9.2.0
+- plotly==5.13.1
+- pooch==1.6.0
+- prettytable==3.4.1
+- pyarrow==9.0.0
+- pypdf2==2.10.4
+- pytables==3.7.0
+- pytest==7.1.2
+- pytest-cov==3.0.0
+- python-pdfkit==1.0.0
+- requests==2.28.2
+- r-base==4.0.5
+- r-tidyverse==1.3.2
+- scikit-image==0.19.3
+- scikit-learn==1.2.2
+- scipy==1.10.1
+- seaborn==0.12.2
+- sphinx-jupyterbook-latex==0.5.2
+- sqlparse==0.4.3
+- statsmodels==0.14.0
+- sympy==1.10.1
+- tornado==6.2.0
+- tqdm==4.64.0
+- xarray==2023.5.0
+- xlrd==2.0.1
+- micro==2.0.8
+- websockify==0.11.0
+- folium==0.14.0
+- sqlalchemy==2.0.16
+- pip
+- pip:
+  # - -r infra-requirements.txt
+  - jupyter-desktop-server
+  - gh-scoped-creds==4.1
+  - otter-grader==4.4.1
+  - otter-submit==0.1.1
+  - ipython-sql==0.4.1
+  - geopandas==0.12.1
+  - iwut==0.0.4
+  - tensorflow-cpu==2.12.0
+  - ipywidgets==8.0.7
+  - jupyter_collaboration==1.0.1
+  - jupyterhub==4.0.1
+  - nbconvert==7.6.0
+  - notebook==7.0.0rc2
+  - pytest-notebook==0.8.1
+  - datascience==0.17.5
 
-  # Visual Studio Code!
-  - jupyter-vscode-proxy
-
-  - pip:
-    - nbforms==0.5.1
-    - nbconvert==6.5.1
-    - nbformat==5.2.0
-    - datascience==0.17.5
-# For grading
-    - -r infra-requirements.txt
-    - otter-grader==4.1.0
-    - gofer-submit==0.5.1

--- a/deployments/data8xv2/image/postBuild
+++ b/deployments/data8xv2/image/postBuild
@@ -1,10 +1,6 @@
 #!/bin/bash -l
 set -euo pipefail
 
-# Code Server needs nodejs 16+ but nodejs is pinned in
-# repo2docker working this out
-mamba install -n notebook -c conda-forge nodejs==16.* code-server>4.5
-
 # Create ipython config directory if it doesn't exist
 mkdir -p ${CONDA_DIR}/etc/ipython
 cp ipython_config.py ${CONDA_DIR}/etc/ipython/ipython_config.py

--- a/deployments/data8xv2/image/start
+++ b/deployments/data8xv2/image/start
@@ -1,7 +1,0 @@
-#!/bin/bash -l
-
-# Install vscode extension at startup time, so it gets
-# put in user home directory.
-code-server --install-extension ms-python.python
-
-exec "$@"

--- a/deployments/data8xv2/secrets/prod.yaml
+++ b/deployments/data8xv2/secrets/prod.yaml
@@ -1,26 +1,26 @@
 jupyterhub:
     hub:
         services:
-            gofer_nb:
+            otter_grade:
                 environment:
-                    LTI_CONSUMER_KEY: ENC[AES256_GCM,data:ohhqyZ7fBGdvgi8mUDMCnaID2alXnfzL8GQYMRRUDyHqh7qE+WQqgNapKBGvP4ZWL0tJMQqZbLku5oin3obCOQ==,iv:HdxlkVjTC4cbX0e+8L3fAHoy3lHFDmycOZlBOsYoYDM=,tag:btQ/GiMml354StZ1Q6oTKQ==,type:str]
-                    LTI_CONSUMER_SECRET: ENC[AES256_GCM,data:/X9M63GWo0SZGw6DsBIHXnxq1+BXZ2r9anCk1KPEaDo8ChULksCuQZzI9q9S62pIbB35AGaBbezbnZk++ww9pA==,iv:tEwADN7Lfai6ws7i3khSunx/ItBaSQmWNUHMOaVBd8Q=,tag:OnB+SyoLJ7DEbETMtL5whA==,type:str]
-                apiToken: ENC[AES256_GCM,data:3kM8OxKN69ZJaU77BjMEVTbljlvUTAI5AK67HYpcesA6lbgYsXw41UR87hhUyWfaw5Rt2lo0ZjUgMQcZ4KX6SQ==,iv:nu//IMO6M0mbYUX43Z7zt9aY7C/Fhncjh/uO9lCfph0=,tag:+KN9ZV/Yr2I0TH4v7KhuuQ==,type:str]
+                    LTI_CONSUMER_KEY: ENC[AES256_GCM,data:L+brOLL1mi6aA0esTzdk04PZ7TeBW6d/M0j3DA1BDvP327fUbgqL1nINu9CHQm7cuXJOTxIfHNJlSG1Uu5Bi1A==,iv:Ng2OX4xHRoQLDL+JS+165zgM8dYRR63QFghuUta/hF4=,tag:46kYnfssjiNtIyHLatWwkQ==,type:str]
+                    LTI_CONSUMER_SECRET: ENC[AES256_GCM,data:GvY/23VtDdBuck6UG00WQhO/+bOnN6UXVtdlVXnvJEmGpNRMLwCygEOb510kdxmWJIuQTj2uHaLDtzdTg3v88w==,iv:k4Q5nOQ/FQOnSpNv+J+iqA9aruYjbgx2jeMKTH9VzQY=,tag:1KeAGeZXz7gExYHWzSVe1g==,type:str]
+                apiToken: ENC[AES256_GCM,data:M/tcDGlQ4Jl49mfHkZOkjmjBnaptJpgBGoecI1qrkDO37f/lU7Apm25ZMoORaV57IsG0hg4SKdXHtDkhHBqXig==,iv:Coerx4fiwtVwD37lzVOgb/4U/1J84t8q911IkF78JvE=,tag:iNzUleTSUX0kNqTrA8RSRA==,type:str]
         config:
             LTI11Authenticator:
                 consumers:
-                    b34eeb75dca9b467b1e074fb3eaeed4717a6aefd28d5e7e2c8c633fb016b2f39: ENC[AES256_GCM,data:flaZMIq32pmzFjiFffChkt3w4X3eQ351By5N0FsYlplvFQ+zABRPpjHHIne4HP+qLno5dUtt45ADKbshfaJ3lg==,iv:S7m1CvVWP+ZcuRAysOl6yDZc5iwBtxMl7ar1rZnk3ME=,tag:bkEOgHSmcAfSJw9wOCu6Xg==,type:str]
+                    b34eeb75dca9b467b1e074fb3eaeed4717a6aefd28d5e7e2c8c633fb016b2f39: ENC[AES256_GCM,data:7Ar8pXjjp/nWvCOH7KMuvzSwL/aGr9LNfSc/wPcEGcLadBnNmYBtqV2vlvVODxkIVPyBJupklbmSVW90BZdtTA==,iv:QlsR3G2r2tyLTFguBuX3BBp/kVKK6OZax8owlPJaeto=,tag:PUYrhUUQIpIT1iS1vk1ztQ==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/ucb-datahub-2018/locations/global/keyRings/datahub/cryptoKeys/sops
-          created_at: "2021-05-05T10:58:00Z"
-          enc: CiQA67O9AKbjDg17FXlVs70AlTSxJlS7V5WHVGNZFP1+oxk+1BkSSQDmhpq8in3GxTmGnIYlWdH62HNhlVgnzfrPRgahWi2uzxxVWfkY0z+vgiEKX6ScHEOPkD7jMnvUZ2OMJl9Nzyeh0uMIQlpBpko=
+          created_at: "2023-07-20T00:20:12Z"
+          enc: CiUA67O9AOODQr+j9f7kfPhTwD5COEw6aSUcif6GII2wkhivmanSEkkAV2r3eZ3zdwwGrV8RRZ3iN3Z/rO65fmsfrMZOF/WJSs49Pq1hUiuVduGd36/Raa4H7Duyx7+5naZtmtE920Rexrk/NaHIkDt9
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-02T12:32:57Z"
-    mac: ENC[AES256_GCM,data:Qp0lSgf5nyD8JJUdreRnCaGytCqktsSpxH+sGM8K1FH4oUX3qsOdnVlMQGHihJxKTTDf9XXBN41FH4cXbaJe4UkyUjGNzHSk69MAb27Q4Eqr4Rk/JWF1AC4CI4ywuGXN9VSjtA2PaupBgufXUaOsXSvgxPQ2scQgCE7B0+AwLIg=,iv:cNtfrvzrpUVYMWiYDdgeOcInP+tCSkv0+or0UPHOTFM=,tag:JNNCZFkV7rzU/IXxJXQUOw==,type:str]
+    lastmodified: "2023-07-20T00:20:13Z"
+    mac: ENC[AES256_GCM,data:bc7N3cizvcjPVhUHzO5fPj0MwG0hXlp79/thQoWxVeup9PQ99iGdvMhVxCJC1QCfUFKq1dm2fZfDLLC85+UU3mzvhO1VF4kvZWFICaUdLQr4fuGp7bajwmF20SjXmLHbECbyddReXY88Q05jB9CvSgM8a0wr3UZ5te62aJ+NJHM=,iv:zRDljmyZOc0NMkq+R/1+MHmA4PNq2HnvmRQbSN0DGK0=,tag:t1d/gXx09iMP8mz6ofGwMw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.1

--- a/deployments/data8xv2/secrets/staging.yaml
+++ b/deployments/data8xv2/secrets/staging.yaml
@@ -1,26 +1,26 @@
 jupyterhub:
     hub:
         services:
-            gofer_nb:
+            otter_grade:
                 environment:
-                    LTI_CONSUMER_KEY: ENC[AES256_GCM,data:7hICqZuDe+8R6XTWGKCOkpOHSocYpshWIyMpYi+41969Kb1CH+8f6n8aanczLmtYbKST5cAq1l7YwN3iFl0VXw==,iv:xOkCy6KFLyp8eE1VYRkjA6VIfo0cQEQ+N/mY3mSYHlY=,tag:IK9SfzZsL9WB5a0F2M037A==,type:str]
-                    LTI_CONSUMER_SECRET: ENC[AES256_GCM,data:kWKLtcpG9rLcJ5iOd37p2NRKyyYv33llwRF1ktR7gAhNU4dRLF5gtvXzFjLYTJ+ssPIFxikccTCae3kB3ZhLtg==,iv:TfaFsLN9Nl66ijefSPdFgU1EhFKCZtLrBgolW3Zfgf0=,tag:moGQ3rdz3FW0Ui1VqDLMsQ==,type:str]
-                apiToken: ENC[AES256_GCM,data:fEoAZmt9odbl19iaoE8xrS4ir0kJUgIK8Y8TbI8XLsk=,iv:n6nxngvmtbKfk/dB39dD2jOz1Z/ieKQ7qfXzlqWWX1U=,tag:ziI/tL+ydSwqkq9lkVXL0w==,type:str]
+                    LTI_CONSUMER_KEY: ENC[AES256_GCM,data:PcGMe9d/nuv2uF/GzeSEACHy4JU65XbooawdC21Vwa20ch8pJTFPpvzKt0yn9DQtwBaQ9n4/MhVAbnmvSBVZ+A==,iv:zoSJQnaIAwfHVe6WmWnrAVBywn/FO2fB6zkETB9X+t4=,tag:q9H5QkR4bwWKMnMTl+vb/g==,type:str]
+                    LTI_CONSUMER_SECRET: ENC[AES256_GCM,data:GZWC6vhGiO1taYloVcZ2Q3cuugd6U5lz6ZoQEp1GV8x8H5yF2KB9IB22M9KwGABjLFc6qvFdfci0oqJILmroFw==,iv:c/O8H3c4ujkrXHTdU+DGm6U4EC6UyWUsc5i4RnJIgcQ=,tag:5lrSnyfLq5j3k2JqmVQLZQ==,type:str]
+                apiToken: ENC[AES256_GCM,data:MXGt1/TgrFzRmLE6d8nS205xl3ZPt5OvUNFRvB3oZkM=,iv:eJRB3RYjrPKUB9f8MbhtaPH/FSAh8RRWLiojT1u5qVc=,tag:CIr9239NvyhGdlTPM1UbMg==,type:str]
         config:
             LTI11Authenticator:
                 consumers:
-                    b34eeb75dca9b467b1e074fb3eaeed4717a6aefd28d5e7e2c8c633fb016b2f39: ENC[AES256_GCM,data:eCTMK2dDx/QNb45lbsT/gyEJoJQC4OjdWwwgyASj9H2oBx/SjElFx86/70YrBCwnUeSTHLQ+x7tn3x2FK17I4Q==,iv:qNoi7yICjv5n3W806z0qK8z303r7sg3AtKR4bBAkSo4=,tag:FkKFWxnAZF7DUsS2jspDCQ==,type:str]
+                    b34eeb75dca9b467b1e074fb3eaeed4717a6aefd28d5e7e2c8c633fb016b2f39: ENC[AES256_GCM,data:8LnXy557TJzrxGTSKnvRF9OoVXQm8XltulbbnT0yKV+0/PyFwfk2ItsJB0vxCPbNTGVV2A+pXRkw5V3rjI9M7w==,iv:Ujpi5fEYRKMgh5sU5+XxOBoAPjjkxAlOYrUSQE7I59g=,tag:wrzsEEbhIMm2EcTNYg5xbA==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/ucb-datahub-2018/locations/global/keyRings/datahub/cryptoKeys/sops
-          created_at: "2022-06-21T16:18:59Z"
-          enc: CiQA67O9AG16+rEhiQAirQgltu+Qw04u7Kkip2tJq4RecpZuotQSSQBX3nT33K0n4IdWUNI/LDIzEVyvt35Pu+fTxeMTvU4bQL88wKnAWmYc9EF/U9TKHK6UgvSKsUpoGhb3ay98RxFkGuN0SOV8oaU=
+          created_at: "2023-07-20T00:17:51Z"
+          enc: CiUA67O9AO1WgVkhn8kG3etbaA1jTolfY7ekX2JXgr1oPoF6ptCWEkkAV2r3eYqKvLuua8XWEwVNX96gA+4hbfONDjZPEP2XqBtELWHGeQPRcy3m3iXciz9ayViOBMwCuMffPdiWjpOdFdqhz9koGV0M
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-21T16:19:00Z"
-    mac: ENC[AES256_GCM,data:JKkeIZdcWe4wcZhD90qSj/GVE0Kt0KT+Sl3gYHFBCj8YpMfbQpqWdAX3C7sM+BExu22KHzpe4a3NI0TcAsiZWwLyTHBbh0sNtqMuHY1kbtodz1qd9XRTePoU8+qzivXmeN2U/zUSbKD4BpCbwOyi3EUPJ/vWJ33CG5yZXEcYSLM=,iv:cg6uptFaKpOYOp9itmdKgqUnByKp9d4ZV7QdFKJ4TAM=,tag:idOXptJVTEiczrrBFeKzyQ==,type:str]
+    lastmodified: "2023-07-20T00:17:51Z"
+    mac: ENC[AES256_GCM,data:DTrwf8A7paWfkM7Obq6C6qV5zyREjVhLiJkVQg6huBEwDsHii+4/4Fg22ZtRyCCSKT0qBLY2623dY1I6glxEr0JfUlKV7MhFL9NvkjwIu8V6oJZw78XrQ1mSKgHajH1uQPa5jIBA33vGJDo/95Yzb1XJ18VZFU7qx9ngcbjvjhE=,iv:6l+afZNvt7/eBHHMRVTy4+XLLUUg81y68jiEulLa9vE=,tag:QGvaUGp4gEzfOtR7mS0QsA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.1


### PR DESCRIPTION
- deployment mirrors data100-jl4 in terms of not using the infra-requirements.txt file
- otter-grader 4.4.1 added
- otter-submit extension added
- changed service endpoint from gofer_nb to otter_grade
- removed support for vscode