### PR TITLE
Update admin template to include info about publishing courses in bcourses

### DIFF
--- a/.github/ISSUE_TEMPLATE/admin_request.yml
+++ b/.github/ISSUE_TEMPLATE/admin_request.yml
@@ -23,7 +23,7 @@ body:
   - type: input
     attributes:
       label: Bcourses Id
-      description: bcourses id for the course you are teaching. You can find that in the URL to your course (It is a six digit number)
+      description: bcourses id for the course you are teaching. You can find that in the URL to your course (It is a six digit number). Please ensure that the course is published in bcourses. If not, Datahub will not get the required group information from an unpublished course in bcourses.
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Prob 140 summer instructors did not get admin access as they were sharing the bcourses ID for an unpublished course. 