### PR TITLE
Pinning scipy to 1.10.0 to solve cartopy package rendering issue in Datahub

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 # We don't want to have conda packages depend on pip packages if possible
 - numpy=1.21.*
 - matplotlib=3.7.*
-- scipy=1.7.*
+- scipy=1.10.0
 - ipympl=0.9.*
 - pandas=1.3.*
 - statsmodels=0.13.5


### PR DESCRIPTION
Based on the recommendation here - https://github.com/SciTools/cartopy/issues/2199#issuecomment-1617221192, I am pinning scipy to 1.10.0. For some reason, scipy 1.11.0 is installed in Datahub which is messing up with the way cartopy functions due to breaking changes

In addition, Stat159 hub pins the [scipy version to 1.10.0](https://github.com/berkeley-dsep-infra/datahub/blob/643fa54b3a378b1bd6abf9695eb5fc2308f03c67/deployments/stat159/image/environment.yml#L94) and cartopy package works fine in this hub

#4800 