### PR TITLE
twice the graphviz, twice the fun?

### DIFF
--- a/deployments/data100-jl4/image/environment.yml
+++ b/deployments/data100-jl4/image/environment.yml
@@ -90,6 +90,7 @@ dependencies:
   - otter-grader==4.0.1
   - jupysql==0.8.0
   - geopandas==0.12.1
+  - graphviz==0.20.1
   - iwut==0.0.4
   - tensorflow-cpu==2.12.0
   - ipywidgets==8.0.7


### PR DESCRIPTION
pip AND conda both have graphviz, and both are named the same, but pip provides the python interface and conda the binary for `dot`.  ¯\\\_(ツ)\_/¯