### PR TITLE
[DH-104] bump calendar autoscaler configs for FA23

### DIFF
--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -78,7 +78,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   biology:
     nodeSelector:
       hub.jupyter.org/pool-name: biology-pool
@@ -86,7 +86,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   cee:
     nodeSelector:
       hub.jupyter.org/pool-name: cee-pool
@@ -94,16 +94,8 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
-  data100:
-    nodeSelector:
-      hub.jupyter.org/pool-name: data100-pool
-    resources:
-      requests:
-        # Some value slightly lower than allocatable RAM on the nodepool
-        memory: 207314055168
     replicas: 1
-  data100-jl4:
+  data100:
     nodeSelector:
       hub.jupyter.org/pool-name: data100-pool
     resources:
@@ -118,7 +110,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   data102:
     nodeSelector:
       hub.jupyter.org/pool-name: data102-pool
@@ -126,7 +118,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   data8:
     nodeSelector:
       hub.jupyter.org/pool-name: data8-pool
@@ -158,7 +150,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   ischool:
     nodeSelector:
       hub.jupyter.org/pool-name: ischool-pool
@@ -166,7 +158,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   publichealth:
     nodeSelector:
       hub.jupyter.org/pool-name: publichealth-pool
@@ -174,7 +166,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   stat159:
     nodeSelector:
       hub.jupyter.org/pool-name: stat159-pool
@@ -182,7 +174,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   stat20:
     nodeSelector:
       hub.jupyter.org/pool-name: stat20-pool
@@ -190,7 +182,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   r:
     nodeSelector:
       hub.jupyter.org/pool-name: r-pool
@@ -198,7 +190,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   small-courses:
     nodeSelector:
       hub.jupyter.org/pool-name: small-courses-pool

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -174,7 +174,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 1
+    replicas: 0
   stat20:
     nodeSelector:
       hub.jupyter.org/pool-name: stat20-pool


### PR DESCRIPTION
bump everything to 1, except:
* delete `data100-jl4` entry
* leave `small-courses` and `stat159` at 0 for now

https://jira-secure.berkeley.edu/browse/DH-104