### PR TITLE
[DH-105] Increase RAM for EE120 in EECS hub

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -77,8 +77,8 @@ jupyterhub:
 
   # read by z2jh.get_config() in hub/values.yaml
   # formerly jupyterhub.hub.extraConfigMap
-  #custom:
-  #  group_profiles:
-  #    canvas::1522650: # EE 120, Spring 2023, issue #4106
-  #      mem_limit: 4096M
-  #      mem_guarantee: 4096M
+  custom:
+    group_profiles:
+      course::1527328: # EE 120, Fall 2023, issue #4868
+        mem_limit: 4096M
+        mem_guarantee: 4096M


### PR DESCRIPTION
As requested in https://github.com/berkeley-dsep-infra/datahub/issues/4868

Replace the config changes for SP 23 with FA 23

trying this for @balajialg as https://github.com/berkeley-dsep-infra/datahub/pull/4875 is still failing due to github api rate limits...  :\