### PR TITLE
Update common.yaml

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -28,7 +28,7 @@ jupyterhub:
           - access:servers!group=course::1527426
         # this role will be assigned to...
         groups:
-          - course::1527426::group::Admins #not fully sure if this number should be the course code (1527426) or the bcourses group code (383808)
+          - course::1527426::group::Admins 
 
 #  prePuller:
 #    extraImages:

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -28,7 +28,7 @@ jupyterhub:
           - access:servers!group=course::1527426
         # this role will be assigned to...
         groups:
-          - Admins::1527426 #not fully sure if this number should be the course code (1527426) or the bcourses group code (383808)
+          - course::1527426::group::Admins #not fully sure if this number should be the course code (1527426) or the bcourses group code (383808)
 
 #  prePuller:
 #    extraImages:

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -17,19 +17,18 @@ jupyterhub:
       hub.jupyter.org/pool-name: core-pool-2023-07-11
     config:
     loadRoles:
-      # Data 100, Summer 2023, #4677
-      course-staff-1525605:
+      # Data 100, Fall 2023
+      course-staff-1527426:
         description: Enable course staff to view and access servers.
         # this role provides permissions to...
         scopes:
           - admin-ui
-          - list:users!group=course::1525605
-          - admin:servers!group=course::1525605
-          - access:servers!group=course::1525605
+          - list:users!group=course::1527426
+          - admin:servers!group=course::1527426
+          - access:servers!group=course::1527426
         # this role will be assigned to...
         groups:
-          - course::1525605::enrollment_type::teacher
-          - course::1525605::enrollment_type::ta
+          - Admins::1527426 #not fully sure if this number should be the course code (1527426) or the bcourses group code (383808)
 
 #  prePuller:
 #    extraImages:


### PR DESCRIPTION
I added the admins group (group ID: 383808) inside the data 100 course (course ID: 1527426). However, based on the [documentation](https://docs.datahub.berkeley.edu/en/latest/admins/howto/course-config.html#assigning-scopes-to-roles), I wasn't sure which sections require the group ID and which ones require the course ID. I've put the course ID in all of them for now, but please correct me if that's wrong.