### PR TITLE
data101 had two deploy blocks, now only one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,12 +294,6 @@ jobs:
           no_output_timeout: 30m
 
       - run:
-          name: Deploy data101
-          command: |
-            hubploy deploy --timeout 30m data101 hub ${CIRCLE_BRANCH}
-          no_output_timeout: 30m
-
-      - run:
           name: Deploy logodev
           command: |
             hubploy deploy --timeout 30m logodev hub ${CIRCLE_BRANCH}


### PR DESCRIPTION
@felder you added two data101 deploy blocks by accident:
`fa8abb53e (Jonathan Felder 2023-08-11 13:07:56 -0700 279)           name: Deploy data101`
`999edaf8f (Jonathan Felder 2023-08-02 13:33:11 -0700 297)           name: Deploy data101`

btw i do indeed despise the general layout reqs for circleci...   ¯\\\_(ツ)_/¯