### PR TITLE
Don't build logodev image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,15 +524,6 @@ workflows:
                 - staging
                 - prod
       - hubploy/build-image:
-          deployment: logodev
-          name: logodev image build
-          # Filters can only be per-job? wtf
-          filters:
-              branches:
-                ignore:
-                - staging
-                - prod
-      - hubploy/build-image:
           deployment: cee
           name: cee image build
           # Filters can only be per-job? wtf


### PR DESCRIPTION
It is the same image as datahub and we should not be building it twice during CI.