### PR TITLE
Bump nodejs to 16.

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -3,7 +3,7 @@
 # pip uses https://peps.python.org/pep-0440/ which does not have =.
 
 dependencies:
-- nodejs=15.*
+- nodejs=16.*
 - pip=22.2.*
 - python=3.9.*
 


### PR DESCRIPTION
This is needed for mystjs. Other hubs like stat159, dev-r, and a11y are newer, and stat159 is at 16 to retain support for vscode.