### PR TITLE
some testing for DH-123

### DIFF
--- a/deployments/a11y/config/common.yaml
+++ b/deployments/a11y/config/common.yaml
@@ -1,3 +1,4 @@
+# this is just a test to merge to staging
 nfsPVC:
   enabled: true
   nfs:

--- a/deployments/a11y/config/common.yaml
+++ b/deployments/a11y/config/common.yaml
@@ -1,4 +1,3 @@
-# this is just a test to merge to staging
 nfsPVC:
   enabled: true
   nfs:

--- a/deployments/a11y/image/apt.txt
+++ b/deployments/a11y/image/apt.txt
@@ -31,3 +31,6 @@ ruby
 
 # Other niceties for command-line work and life
 rsync
+
+# yes, emacs for testing!
+emacs


### PR DESCRIPTION
i am investigating https://jira-secure.berkeley.edu/projects/DH/issues/DH-123

this change only adds a comment to `common.yaml` for  the a11y hub.  i have opened up 3 notebooks for @felder , @balajialg and myself.

after i merge to staging/prod, i will see if these notebook servers on a11y are killed or not.