### PR TITLE
removing nb2pdf

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -88,6 +88,9 @@ dependencies:
 # MUSIC 30, https://github.com/berkeley-dsep-infra/datahub/issues/5047
 - music21==8.3.0
 
+# error converting to PDF https://github.com/berkeley-dsep-infra/datahub/issues/5062
+- pyppeteer==1.0.2
+
 - pip:
   # Econ 148, Spring 2023 https://github.com/berkeley-dsep-infra/datahub/issues/4093
   - pycountry-convert==0.7.2

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -17,7 +17,7 @@ nose==1.3.7
 #
 # modules
 beautifulsoup4==4.9.3
-nb2pdf==0.6.2
+# nb2pdf==0.6.2 commented out by sknapp 06.10.2023 to unblock https://github.com/berkeley-dsep-infra/datahub/issues/5062
 #
 # ls 88-3; neuro
 lxml==4.9.1


### PR DESCRIPTION
this is blocking https://github.com/berkeley-dsep-infra/datahub/issues/5062

i confirmed that otter 4.2.0 doesn't need this package to work:

https://github.com/ucbds-infra/otter-grader/blob/345e713299522dd542b7b538c9e05a7d29233f4a/otter/export/__init__.py#L4

just to make it extra special, py2pdf hasn't been touched in almost 4 years.  :)