### PR TITLE
[DH-66] move python popcon from infra-reqs to environment.yaml

### DIFF
--- a/deployments/data100/image/environment.yml
+++ b/deployments/data100/image/environment.yml
@@ -43,3 +43,4 @@ dependencies:
   - nbconvert==7.6.0
   - pytest-notebook==0.8.1
   - gh-scoped-creds==4.1
+  - popularity-contest==0.4.1

--- a/deployments/data101/image/environment.yml
+++ b/deployments/data101/image/environment.yml
@@ -101,3 +101,4 @@ dependencies:
   - pytest-notebook==0.8.1
   - pymongo==4.4.1
   - dbt-postgres==1.6.0
+  - popularity-contest==0.4.1

--- a/deployments/data102/image/environment.yml
+++ b/deployments/data102/image/environment.yml
@@ -44,3 +44,4 @@ dependencies:
   - gh-scoped-creds==4.1
   - nb2pdf==0.6.2
   - nbpdfexport==0.2.1
+  - popularity-contest==0.4.1


### PR DESCRIPTION
we're not seeing the popularity contest running on many hubs, and after poking around it seems that at least for some it's not being installed as `infra-requirements.txt` is commented out.