### PR TITLE
[DH-66] duplicate install of `jupyter-rsession-proxy` might be breaking things

### DIFF
--- a/deployments/publichealth/image/Dockerfile
+++ b/deployments/publichealth/image/Dockerfile
@@ -59,9 +59,6 @@ RUN pip install --no-cache-dir -r /tmp/infra-requirements.txt
 
 RUN mamba install -c conda-forge syncthing==1.18.6
 
-# Support latest RStudio
-RUN pip install --no-cache 'jupyter-rsession-proxy>=2.0'
-
 # Install IRKernel
 RUN R --quiet -e "install.packages('IRkernel', quiet = TRUE)" && \
     R --quiet -e "IRkernel::installspec(prefix='${CONDA_DIR}')"

--- a/deployments/publichealth/image/infra-requirements.txt
+++ b/deployments/publichealth/image/infra-requirements.txt
@@ -8,6 +8,7 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
+traitlets==5.9.0
 notebook==6.4.12
 jupyterlab==3.4.5
 retrolab==0.3.21


### PR DESCRIPTION
`jupyter-rsession-proxy` is installed both via the dockerfile and environment.yml, only needs to happen once.  let's try environment.yml first!