### PR TITLE
Update syncthing to the latest stable version in Ischool hub image 

### DIFF
--- a/deployments/ischool/image/environment.yml
+++ b/deployments/ischool/image/environment.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 
 dependencies:
-- syncthing==1.22.2
+- syncthing==1.25.0
 - jupyter-rsession-proxy==2.2.0
 # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048
 - traitlets=5.9.*


### PR DESCRIPTION
and primarily to rebuild the Ischool image so that the latest Stargazer package version 5.2.3 gets added as part of the image - https://jira-secure.berkeley.edu/browse/DH-170