### PR TITLE
[DH-177] bump scipy to make error go away

### DIFF
--- a/deployments/data8/image/environment.yml
+++ b/deployments/data8/image/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - matplotlib==3.4.3
 - ipympl==0.7.0
 - pandas==1.3.2
-- scipy==1.7.1
+- scipy==1.11.3
 - statsmodels==0.12.2
 - seaborn==0.11.2
 # Otter is pulled in via infra-requirements.txt, since it's present in all hubs

--- a/deployments/data8/image/environment.yml
+++ b/deployments/data8/image/environment.yml
@@ -26,5 +26,5 @@ dependencies:
 # Conda only has 0.12.0
   - folium==0.12.1
   - okpy==1.18.1
-  - datascience==0.17.0
+  - datascience==0.17.6
   - otter-grader==4.3.4 # Based on request from ericvd and sean.morris


### PR DESCRIPTION
data8 was getting this error:

```
/srv/conda/lib/python3.9/site-packages/scipy/__init__.py:146: UserWarning: A NumPy version >=1.16.5 and <1.23.0 is required for this version of SciPy (detected version 1.26.0
  warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion}"
```

this should fix it