### PR TITLE
[DH-182] critical security update for ray

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -251,7 +251,7 @@ dependencies:
   - ipycanvas==0.9.0
 
   # data100 scientific packages
-  - ray==1.13.*
+  - ray==2.8.0
   - xlrd==2.0.1
 
   # data100 visualization


### PR DESCRIPTION
there are three critical security issues in ray:
https://github.com/berkeley-dsep-infra/datahub/security/dependabot/73
https://github.com/berkeley-dsep-infra/datahub/security/dependabot/74
https://github.com/berkeley-dsep-infra/datahub/security/dependabot/75

we're on 1.3, we need to upgrade to at least 2.6.  i'll go for latest (2.8).

this is pretty bad, so i'll shepherd this through and get it out today.

@balajialg @ryanlovett @felder 