### PR TITLE
[DH-189] Setting Ischool hub to launch JupyterLab by default

### DIFF
--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -43,7 +43,7 @@ jupyterhub:
           - dhughes
 
   singleuser:
-    defaultUrl: /rstudio
+    defaultUrl: /lab
     nodeSelector:
       hub.jupyter.org/pool-name: ischool-pool
     storage:


### PR DESCRIPTION
Getting some low-hanging fruits done for this JIRA ticket - https://jira-secure.berkeley.edu/browse/DH-189

Ref: https://github.com/berkeley-dsep-infra/datahub/issues/5251