### PR TITLE
break out the apt R install steps for debugging/unsticking

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -38,15 +38,13 @@ RUN install -d -o ${NB_USER} -g ${NB_USER} ${R_LIBS_USER}
 # These packages must be installed into the base stage since they are in system
 # paths rather than /srv.
 # Pre-built R packages from rspm are built against system libs in jammy.
-ENV R_VERSION=4.3.1-1.2204.0
+ENV R_VERSION=4.3.2-1.2204.0
 ENV LITTLER_VERSION=0.3.18-2.2204.0
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" > /etc/apt/sources.list.d/cran.list
 RUN curl --silent --location --fail https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc > /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
-RUN apt-get update --yes > /dev/null
-RUN apt-get install --yes -qq r-base-core=${R_VERSION}
-RUN apt-get install --yes -qq r-base-dev=${R_VERSION}
-RUN apt-get install --yes -qq littler=${LITTLER_VERSION}
+RUN apt-get update --yes > /dev/null && \
+    apt-get install --yes -qq r-base-core=${R_VERSION} r-base-dev=${R_VERSION} littler=${LITTLER_VERSION} > /dev/null
 
 ENV RSTUDIO_URL https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2023.06.0-421-amd64.deb
 RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -43,11 +43,10 @@ ENV LITTLER_VERSION=0.3.18-2.2204.0
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" > /etc/apt/sources.list.d/cran.list
 RUN curl --silent --location --fail https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc > /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
-RUN apt-get update -qq --yes > /dev/null && \
-    apt-get install --yes -qq \
-    r-base-core=${R_VERSION} \
-    r-base-dev=${R_VERSION} \
-    littler=${LITTLER_VERSION} > /dev/null
+RUN apt-get update --yes > /dev/null
+RUN apt-get install --yes -qq r-base-core=${R_VERSION}
+RUN apt-get install --yes -qq r-base-dev=${R_VERSION}
+RUN apt-get install --yes -qq littler=${LITTLER_VERSION}
 
 ENV RSTUDIO_URL https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2023.06.0-421-amd64.deb
 RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \


### PR DESCRIPTION
see https://github.com/berkeley-dsep-infra/datahub/pull/5332

i was able to build the datahub image locally after breaking these apt-get installs out in to their own RUN blocks.  not sure why that helped, but we can at least test that out in circleci.