### PR TITLE
Change default URL for Data 8 hub to "/tree" and add entry for JUPYTERHUB_SINGLEUSER_APP

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -59,7 +59,7 @@ jupyterhub:
   singleuser:
     nodeSelector:
       hub.jupyter.org/pool-name: data8-pool
-    defaultUrl: /retro
+    defaultUrl: /tree
     storage:
       type: static
       static:

--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -57,6 +57,9 @@ jupyterhub:
       #    - course::N::enrollment_type::ta
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: data8-pool
     defaultUrl: /tree


### PR DESCRIPTION
Changing the default URL from "/retro" to "/tree" based on docs - https://jupyter-notebook.readthedocs.io/en/v7.0.1/migrating/multiple-interfaces.html#nbclassic-and-notebook-7