### PR TITLE
bump circleci runner size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ orbs:
         docker:
           - image: python:3.9-slim-bullseye
         working_directory: ~/repo
+        resource_class: xlarge
         steps:
           - checkout
           - run:


### PR DESCRIPTION
our datahub build is timing out again and taking over 2hrs to complete.  maybe this helps?