### PR TITLE
[DH-194] notebook 7 settings

### DIFF
--- a/deployments/astro/config/common.yaml
+++ b/deployments/astro/config/common.yaml
@@ -46,6 +46,9 @@ jupyterhub:
         groups:
           - course::1524699::group::astro-admins
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: astro-pool
     storage:

--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -56,6 +56,9 @@ jupyterhub:
           mountPath: /home/jovyan/shared-readwrite
           subPath: _shared
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     extraFiles:
       git-credential-helper:
         mountPath: /etc/gitconfig

--- a/deployments/cee/config/common.yaml
+++ b/deployments/cee/config/common.yaml
@@ -34,6 +34,9 @@ jupyterhub:
         groups:
           - course::1524699::group::all-admins
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     defaultUrl: /desktop
     nodeSelector:
       hub.jupyter.org/pool-name: cee-pool

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -95,6 +95,9 @@ jupyterhub:
       nodeSelector:
         hub.jupyter.org/pool-name: core-pool-2023-12-21
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: datahub-pool
     storage:

--- a/deployments/dev-r/config/common.yaml
+++ b/deployments/dev-r/config/common.yaml
@@ -58,6 +58,9 @@ jupyterhub:
       #    - course::N::enrollment_type::ta
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     defaultUrl: /rstudio
     profileList:
       - display_name: "Dockerfile image"

--- a/deployments/dlab/config/common.yaml
+++ b/deployments/dlab/config/common.yaml
@@ -49,6 +49,9 @@ jupyterhub:
         groups:
           - course::1524699::group::dlab-admins
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: dlab-pool
     storage:

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -57,6 +57,8 @@ jupyterhub:
       # Tell code where to display GUIs
       # The VNC /desktop link must be opened already for this to work
       DISPLAY: ":1.0"
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     defaultUrl: "/lab"
     extraFiles:
       git-credential-helper:

--- a/deployments/highschool/config/common.yaml
+++ b/deployments/highschool/config/common.yaml
@@ -41,6 +41,9 @@ jupyterhub:
         - sfhs.com
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: small-courses-pool
     storage:

--- a/deployments/ischool/config/common.yaml
+++ b/deployments/ischool/config/common.yaml
@@ -61,6 +61,9 @@ jupyterhub:
           - course::1524699::group::ischool-admins
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     defaultUrl: /lab
     nodeSelector:
       hub.jupyter.org/pool-name: ischool-pool

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -40,6 +40,8 @@ jupyterhub:
       # Tell code where to display GUIs
       # The VNC /desktop link must be opened already for this to work
       DISPLAY: ":1.0"
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: small-courses-pool
     storage:

--- a/deployments/logodev/config/common.yaml
+++ b/deployments/logodev/config/common.yaml
@@ -38,6 +38,9 @@ jupyterhub:
         c.JupyterHub.logo_file = '/srv/logos/dlab-logo-notebook.png'
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: small-courses-pool
     storage:

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -53,6 +53,9 @@ jupyterhub:
       hub.jupyter.org/pool-name: core-pool-2023-12-21
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: prob140-pool
     storage:

--- a/deployments/publichealth/config/common.yaml
+++ b/deployments/publichealth/config/common.yaml
@@ -67,6 +67,9 @@ jupyterhub:
       hub.jupyter.org/pool-name: core-pool-2023-12-21
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     defaultUrl: /rstudio
 
     nodeSelector:

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -46,6 +46,9 @@ jupyterhub:
           - course::1524699::group::all-admins
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: r-pool
     storage:

--- a/deployments/shiny/config/common.yaml
+++ b/deployments/shiny/config/common.yaml
@@ -46,6 +46,9 @@ jupyterhub:
         groups:
           - course::1524699::group::all-admins
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: small-courses-pool
     storage:

--- a/deployments/stat20/config/common.yaml
+++ b/deployments/stat20/config/common.yaml
@@ -47,6 +47,9 @@ jupyterhub:
           - course::1524699::group::all-admins
 
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: stat20-pool
     defaultUrl: /rstudio

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -34,6 +34,9 @@ jupyterhub:
         groups:
           - course::1524699::group::all-admins
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       hub.jupyter.org/pool-name: {{cookiecutter.pool_name}}
     storage:

--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -35,6 +35,9 @@ jupyterhub:
       nodeSelector:
         hub.jupyter.org/pool-name: core-pool-2023-12-21
   singleuser:
+    extraEnv:
+      # Unset NotebookApp from hub/values. Necessary for recent lab versions.
+      JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:
       # Co-locate with datahub, since workshop shares its image
       hub.jupyter.org/pool-name: datahub-pool


### PR DESCRIPTION
this is to fix the following error:

```
/srv/conda/envs/notebook/lib/python3.9/subprocess.py:941: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/bin/jupyterhub-singleuser", line 5, in <module>
    from jupyterhub.singleuser import main
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/jupyterhub/singleuser/__init__.py", line 67, in <module>
    from .app import SingleUserNotebookApp, main
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/jupyterhub/singleuser/app.py", line 44, in <module>
    raise ImportError(
ImportError: JUPYTERHUB_SINGLEUSER_APP=notebook.notebookapp.NotebookApp is not valid with notebook>=7 (have notebook==7.0.6).
Leave $JUPYTERHUB_SINGLEUSER_APP unspecified (or use the default JUPYTERHUB_SINGLEUSER_APP=jupyter-server), and set `c.Spawner.default_url = "/tree"` to make notebook v7 the default UI.
```