### PR TITLE
Adding nbconvert-a11y to a11y image

### DIFF
--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -31,6 +31,7 @@ dependencies:
   # https://github.com/berkeley-dsep-infra/datahub/issues/3693
   - notebook==7.1.0a1
   - jupyterlab==4.1.0b0
+  - nbconvert-a11y==2023.12.6
   # ###
   # The items below are from infra-requirements, however lab conflicts with the
   # alpha notebook.


### PR DESCRIPTION
Can't find an entry in Anaconda.org

https://pypi.org/project/nbconvert-a11y/

Testing whether nbconvert-a11y solves the issue reported in the datahubs slack channel