### PR TITLE
[DH-216] Remove PDF generation options that are no longer required by Data 8 instructional team

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -57,6 +57,14 @@ jupyterhub:
       #    - course::N::enrollment_type::ta
 
   singleuser:
+    extraFiles:
+      # DH-216 Removing QtPDF, QtPNG as per Data 8 GSI inputs
+      remove-exporters:
+        mountPath: /etc/jupyter/jupyter_notebook_config.py
+        stringData: |
+          c.QtPDFExporter.enabled = False
+          c.QtPNGExporter.enabled = False
+          c.WebPDFExporter.enabled = False
     extraEnv:
       # Unset NotebookApp from hub/values. Necessary for recent lab versions.
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"


### PR DESCRIPTION
Got the confirmation from Sarah Song (Data 8 GSI) that the only PDF generation option they use as part of their instructional workflow is "File -> Save and Export Notebook As... -> PDF". All other options are deemed unnecessary. Furthermore, certain options that have been removed from the UI are currently buggy and non-functional in the Data 8 hub.

Reference: 
https://nbconvert.readthedocs.io/en/latest/config_options.html