### PR TITLE
[DH-217] remove EOLed docker version from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,11 +87,7 @@ orbs:
                     chmod 755 ${HOME}/repo/bin/sops
                     echo 'export PATH="${HOME}/repo/bin:${PATH}"' >> ${BASH_ENV}
 
-          - setup_remote_docker:
-              # fixes a docker permission problem
-              # https://support.circleci.com/hc/en-us/articles/360050934711
-              # https://circleci.com/docs/2.0/building-docker-images/
-              version: 20.10.17
+          - setup_remote_docker
           - save_cache:
               paths:
                 - ./venv

--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -25,8 +25,6 @@ dependencies:
 - jupyterthemes==0.20.0
 - jupyterlab-accessible-themes==0.1.1  
 - jupyterlab_pygments==0.2.2
-# just to trigger an image build
-- pandas
 - pip:
   #- -r infra-requirements.txt
   # Upgrade separate from what everyone else uses for now

--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -25,6 +25,8 @@ dependencies:
 - jupyterthemes==0.20.0
 - jupyterlab-accessible-themes==0.1.1  
 - jupyterlab_pygments==0.2.2
+# just to trigger an image build
+- pandas
 - pip:
   #- -r infra-requirements.txt
   # Upgrade separate from what everyone else uses for now


### PR DESCRIPTION
i will revert the change to the a11y image once i've confirmed that builds work.