### PR TITLE
bump lwgeom to fix error message during build

### DIFF
--- a/deployments/datahub/images/default/install.R
+++ b/deployments/datahub/images/default/install.R
@@ -109,7 +109,7 @@ cran_packages = c(
   "listenv", "0.8.0",
   "lpSolve", "5.6.15",
   "lubridate", "1.7.9.2",
-  "lwgeom", "0.2-5",
+  "lwgeom", "0.2-13",
   "magic", "1.5-9",
   "manipulateWidget", "0.10.1",
   "mapdata", "2.3.0",


### PR DESCRIPTION
this was buried in the build logs:

```
Installing 1 packages: lwgeom
Warning: unable to access index for repository http://gis-bigdata.uni-muenster.de/pebesma/src/contrib:
  cannot open URL 'http://gis-bigdata.uni-muenster.de/pebesma/src/contrib/PACKAGES'
```