### PR TITLE
[DH-205] fix prom pod label to enable scraping

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -95,7 +95,7 @@ prometheus:
       limits:
         cpu: 7
         memory: 48Gi
-    labels:
+    podLabels:
       # For HTTP access to the hub, to scrape metrics
       hub.jupyter.org/network-access-hub: 'true'
     persistentVolume:


### PR DESCRIPTION
![image](https://github.com/berkeley-dsep-infra/datahub/assets/1606572/62de1dc5-0569-4fac-9316-d50f021a3df2)
