### PR TITLE
Fixing information in admin access github template

### DIFF
--- a/.github/ISSUE_TEMPLATE/admin_request.yml
+++ b/.github/ISSUE_TEMPLATE/admin_request.yml
@@ -23,7 +23,7 @@ body:
   - type: input
     attributes:
       label: bCourses ID
-      description: bCourses ID for the course you are teaching. You can find that in the URL to your course -- it is a six digit number. The course needs to be set to Published in bCourses, otherwise the hub will not be able to assign extra privileges.
+      description: bCourses ID for the course you are teaching. You can find that in the URL to your course -- it is a seven digit number. The course needs to be set to Published in bCourses, otherwise the hub will not be able to assign extra privileges.
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Course instructor pointed out that bcourses id is a 7-digit number!