### PR TITLE
Enable nbconvert PDF conversion option in R Hub

### DIFF
--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -52,7 +52,7 @@ jupyterhub:
         mountPath: /etc/jupyter/jupyter_notebook_config.py
         stringData: |
           c.QtPDFExporter.enabled = False
-          c.PDFExporter.enabled = False
+          #c.PDFExporter.enabled = False
     extraEnv:
       # Unset NotebookApp from hub/values. Necessary for recent lab versions.
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"


### PR DESCRIPTION
Might fix https://github.com/berkeley-dsep-infra/datahub/issues/5457

Ottr seems to use[ nbconvert's PDF generation](https://github.com/ucbds-infra/ottr/pull/17/commits/56e68bfece4172e7db5c99e54e724a9f908daae7#) option to export notebooks as zip ([Reference](https://github.com/ucbds-infra/ottr/blob/a5e2ae52f0c4377fb82886eb4cf27d47564222e9/R/export.R#L56) to the code). We removed the [PDF generation option](https://github.com/berkeley-dsep-infra/datahub/pull/5406) across multiple hubs as part of our clean-up.

I reviewed [Ottr's github issue](https://github.com/ucbds-infra/otter-grader/issues/440) and the corresponding changes added as Python code which adds the functionality to export the notebook as a PDF. I assume that enabling the PDF option in the R hub config might fix the issue reported by David. 

Thoughts? I can close the PR if it doesn't fix the issue