### PR TITLE
Increase RAM for Econ 148

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -86,6 +86,12 @@ jupyterhub:
       course::1531798::group::Content: # Spring 2024 Content Team, ensured 4G RAM
         mem_limit: 4G
         mem_guarantee: 4G
+
+      # Econ 148, Spring 2024
+      course::1532866: # Temporarily grant 3G of RAM to all students
+        mem_limit: 3G
+        mem_guarantee: 3G
+      
     admin:
       mem_limit: 4G
       mem_guarantee: 2G


### PR DESCRIPTION
Hi, this is my attempt to increase the RAM for class econ 148. Our project 1 should require around ~3GB of RAM and be due on Feb 25 (not including possible DSP extensions). We were hoping to release the project on Thursday, so it'd be awesome if this could be merged before then. Sorry if I messed up any formatting!