### PR TITLE
[DH-225] Fix configs for providing elevated privileges to ECON 148 course staff in Data 100 Hub

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -44,6 +44,18 @@ jupyterhub:
         # this role will be assigned to...
         groups:
           - course::1531798::group::Admins
+      # Econ 148, Spring 2024, DH-225
+      course-staff-1532866:
+        description: Enable course staff to view and access servers.
+        # this role provides permissions to...
+        scopes:
+          - admin-ui
+          - list:users!group=course::1532866
+          - admin:servers!group=course::1532866
+          - access:servers!group=course::1532866
+        # this role will be assigned to...
+        groups:
+          - course::1532866::group::Admins
 
 #  prePuller:
 #    extraImages:
@@ -92,10 +104,6 @@ jupyterhub:
       course::1532866: # Temporarily grant 3G of RAM to all students
         mem_limit: 3G
         mem_guarantee: 3G
-
-      # Econ 148 Admins, Spring 2024
-      course::1532866::group::admin: # Give Rohan admin access
-        admin: true
       
     admin:
       mem_guarantee: 2G

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -55,7 +55,7 @@ jupyterhub:
           - access:servers!group=course::1532866
         # this role will be assigned to...
         groups:
-          - course::1532866::group::Admins
+          - course::1532866::group::admin
 
 #  prePuller:
 #    extraImages:


### PR DESCRIPTION
@rohanjha123 - Going forward, Recommended approach from infra admins is to provide elevated privileges in the way it is added in this PR. Link to the relevant [documentation](https://docs.datahub.berkeley.edu/en/latest/admins/howto/course-config.html#assigning-scopes-to-roles)