### PR TITLE
Adding shared directory to Econ 148 based on bcourses group affiliation

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -107,10 +107,10 @@ jupyterhub:
 
       # Econ148, Spring '24; testing shared_readwrite for groups in Eric's class
       course::1532866::group::shared_readwrite:
-        - mountPath: /home/jovyan/shared
-          name: home
-          subPath: _shared
-          readOnly: true      
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared    
     admin:
       mem_guarantee: 2G
       extraVolumeMounts:

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -109,7 +109,7 @@ jupyterhub:
       course::1532866::group::shared_readwrite:
         extraVolumeMounts:
           - name: home
-            mountPath: /home/jovyan/econ148-readwrite
+            mountPath: /home/jovyan/_shared-econ148
             subPath: _shared    
     admin:
       mem_guarantee: 2G

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -109,7 +109,7 @@ jupyterhub:
       course::1532866::group::shared_readwrite:
         extraVolumeMounts:
           - name: home
-            mountPath: /home/jovyan/shared-readwrite
+            mountPath: /home/jovyan/econ148-readwrite
             subPath: _shared    
     admin:
       mem_guarantee: 2G

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -104,7 +104,13 @@ jupyterhub:
       course::1532866: # Temporarily grant 3G of RAM to all students
         mem_limit: 3G
         mem_guarantee: 3G
-      
+
+      # Econ148, Spring '24; testing shared_readwrite for groups in Eric's class
+      course::1532866::group::shared_readwrite:
+        - mountPath: /home/jovyan/shared
+          name: home
+          subPath: _shared
+          readOnly: true      
     admin:
       mem_guarantee: 2G
       extraVolumeMounts:


### PR DESCRIPTION
Just testing the functionality to have a shared/shread read write directories for a group based on bcourses affiliation.

@ericvd-ucb gave his approval to use Econ 148 as a guinea pig for this functionality.

Reviewed the documentation [here](https://docs.datahub.berkeley.edu/en/latest/admins/howto/course-config.html#defining-user-profiles) to make this change

bcourses group for reference,

<img width="1274" alt="image" src="https://github.com/berkeley-dsep-infra/datahub/assets/2306166/a300f55f-0559-4609-b8e5-76ec2746ec93">
