### PR TITLE
[DH-228] Provide more RAM for EE 120; Add configs for admins

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -86,3 +86,14 @@ jupyterhub:
       guarantee: 0.1
     image: {}
 
+  custom:
+    group_profiles:
+      # DataHub Infrastructure staff
+      # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
+      course::1524699::group::all-admins:
+        admin: true
+      course::1532904: # EE120, Spring 2024, issue #5492
+        mem_limit: 4096M
+        mem_guarantee: 4096M
+
+


### PR DESCRIPTION
Solves for #5492; Didn't have entries to provide admin access
 for infra admins - so added them to the config 

![image](https://github.com/berkeley-dsep-infra/datahub/assets/2306166/5a54f7ab-8345-4662-84e8-c094e4dadfcd)
