### PR TITLE
[DH-3] try using a test fork of the chp

### DIFF
--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 0.0.1-0.dev.git.7370.h98d3927c
+version: 0.0.1-0.dev.git.7432.hbb8e6e83

--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 0.0.1-0.dev.git.7433.h7f216c94
+version: 0.0.1-0.dev.git.7435.hd97afe24

--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 0.0.1-0.dev.git.7432.hbb8e6e83
+version: 0.0.1-0.dev.git.7433.h7f216c94

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -44,8 +44,8 @@ jupyterhub:
       extraCommandLineFlags:
         # set the timeout and proxyTimeout to 24 hours (arg is in milliseconds)
         # https://github.com/http-party/node-http-proxy?tab=readme-ov-file#options
-        - "--timeout 86400000"
-        - "--proxyTimeout 86400000"
+        - "--timeout=86400000"
+        - "--proxyTimeout=86400000"
       resources:
         requests:
           # FIXME: We want no guarantees here!!!

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -53,7 +53,7 @@ jupyterhub:
           cpu: 0.001
           memory: 64Mi
         limits:
-          memory: 1Gi
+          memory: 1.5Gi
     traefik:
       resources:
         requests:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -42,6 +42,8 @@ jupyterhub:
       image:
         tag: 4.6.1-fork
       extraCommandLineFlags:
+        # set the timeout and proxyTimeout to 24 hours (arg is in milliseconds)
+        # https://github.com/http-party/node-http-proxy?tab=readme-ov-file#options
         - "--timeout 86400000"
         - "--proxyTimeout 86400000"
       resources:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -32,6 +32,15 @@ jupyterhub:
     service:
       type: ClusterIP
     chp:
+      # testing out a potential fix for the chp leaking ports
+      # https://github.com/jupyterhub/configurable-http-proxy/issues/434
+      # https://github.com/jupyterhub/configurable-http-proxy/issues/434#issuecomment-1924261459
+      # https://github.com/http-party/node-http-proxy/pull/1559
+      # https://github.com/Jimbly/http-proxy-node16/commit/56283e33edfc7aad8c2605dd493da8a196b4371d
+      # https://github.com/consideRatio/configurable-http-proxy/commits/main/
+      #
+      image:
+        tag: 4.6.1-fork
       resources:
         requests:
           # FIXME: We want no guarantees here!!!

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -45,7 +45,7 @@ jupyterhub:
         # set the timeout and proxyTimeout to 24 hours (arg is in milliseconds)
         # https://github.com/http-party/node-http-proxy?tab=readme-ov-file#options
         - "--timeout=86400000"
-        - "--proxyTimeout=86400000"
+        - "--proxy-timeout=86400000"
       resources:
         requests:
           # FIXME: We want no guarantees here!!!

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -41,6 +41,9 @@ jupyterhub:
       #
       image:
         tag: 4.6.1-fork
+      extraCommandLineFlags:
+        - "--timeout 86400000"
+        - "--proxyTimeout 86400000"
       resources:
         requests:
           # FIXME: We want no guarantees here!!!

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -44,8 +44,8 @@ jupyterhub:
       extraCommandLineFlags:
         # set the timeout and proxyTimeout to 24 hours (arg is in milliseconds)
         # https://github.com/http-party/node-http-proxy?tab=readme-ov-file#options
-        - "--timeout=86400000"
-        - "--proxy-timeout=86400000"
+        # - "--timeout=86400000"
+        # - "--proxy-timeout=86400000"
       resources:
         requests:
           # FIXME: We want no guarantees here!!!

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-0.dev.git.7305.h0a2e62d9
+version: 0.0.1-0.dev.git.7371.h371a4a22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-0.dev.git.7371.h371a4a22
+version: 0.0.1-0.dev.git.7433.h7f216c94
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-0.dev.git.7433.h7f216c94
+version: 0.0.1-0.dev.git.7434.h9c1949f1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
@consideRatio pointed me to this...  there were a couple of memory leaks in `node-http-proxy` that haven't been rolled in to a release yet, so let's test this out and see if it helps.

https://github.com/jupyterhub/configurable-http-proxy/issues/434#issuecomment-1924261459
https://github.com/http-party/node-http-proxy/pull/1559
https://github.com/Jimbly/http-proxy-node16/commit/56283e33edfc7aad8c2605dd493da8a196b4371d
https://github.com/consideRatio/configurable-http-proxy/commits/main/