### PR TITLE
move our image build jobs from xlarge runners to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ orbs:
         docker:
           - image: python:3.9-slim-bullseye
         working_directory: ~/repo
-        resource_class: xlarge
+        resource_class: large
         steps:
           - checkout
           - run:


### PR DESCRIPTION
we are burning through credits, lets scale down a bit for our build runners