### PR TITLE
Increase RAM for Astro 128 course in Astro Hub

### DIFF
--- a/deployments/astro/config/common.yaml
+++ b/deployments/astro/config/common.yaml
@@ -45,19 +45,6 @@ jupyterhub:
         # this role will be assigned to...
         groups:
           - course::1524699::group::astro-admins
-      # Astro Lab 128, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5596
-      course-staff-1532117:
-        description: Enable course staff to view and access servers.
-        # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1532117
-          - admin:servers!group=course::1532117
-          - access:servers!group=course::1532117
-        # this role will be assigned to...
-        groups:
-          - course::1532117::enrollment_type::teacher
-          - course::1532117::enrollment_type::ta
 
   singleuser:
     extraFiles:
@@ -90,6 +77,11 @@ jupyterhub:
   # read by z2jh.get_config() in hub/values.yaml
   # formerly jupyterhub.hub.extraConfigMap
   custom:
+    group_profiles:
+      # Astro Lab 128, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5596
+      course::1532117: # Temporarily grant 8G RAM to all students
+        mem_limit: 8G
+        mem_guarantee: 8G
     admin:
       extraVolumeMounts:
         - name: home

--- a/deployments/astro/config/common.yaml
+++ b/deployments/astro/config/common.yaml
@@ -45,6 +45,20 @@ jupyterhub:
         # this role will be assigned to...
         groups:
           - course::1524699::group::astro-admins
+      # Astro Lab 128, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5596
+      course-staff-1532117:
+        description: Enable course staff to view and access servers.
+        # this role provides permissions to...
+        scopes:
+          - admin-ui
+          - list:users!group=course::1532117
+          - admin:servers!group=course::1532117
+          - access:servers!group=course::1532117
+        # this role will be assigned to...
+        groups:
+          - course::1532117::enrollment_type::teacher
+          - course::1532117::enrollment_type::ta
+
   singleuser:
     extraFiles:
       # DH-216


### PR DESCRIPTION
Ref: https://github.com/berkeley-dsep-infra/datahub/issues/5596

From my limited undestanding, Astro 128 course is the only course using Astro hub. Still, didn't want to take any chances

<img width="736" alt="image" src="https://github.com/berkeley-dsep-infra/datahub/assets/2306166/ebd3d87f-8449-469b-90ca-43b14395b63b">
