### PR TITLE
Bump jupyter-server-proxy to 4.1.2.

### DIFF
--- a/deployments/astro/image/environment.yml
+++ b/deployments/astro/image/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
 - python=3.9.*
-
+- jupyter-server-proxy==4.1.1
 # A linux desktop environment
 - websockify
 

--- a/deployments/astro/image/environment.yml
+++ b/deployments/astro/image/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
 - python=3.9.*
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 # A linux desktop environment
 - websockify
 

--- a/deployments/biology/image/environment.yml
+++ b/deployments/biology/image/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - nb_conda_kernels=2.3.1
 
 # proxy web applications
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter-rsession-proxy==2.2.0
 
 # Packages from bioconda for IB134L

--- a/deployments/biology/image/environment.yml
+++ b/deployments/biology/image/environment.yml
@@ -8,6 +8,10 @@ dependencies:
 # Package to allow Jupyter Notebook or JupyterLab applications in one conda env to access other kernels (e.g. qiime2)
 - nb_conda_kernels=2.3.1
 
+# proxy web applications
+- jupyter-server-proxy==4.1.1
+- jupyter-rsession-proxy==2.2.0
+
 # Packages from bioconda for IB134L
 # - bwa=0.7.12
 - samtools=1.3.1
@@ -69,7 +73,6 @@ dependencies:
 # Packages for MCB-160L iss #3942
   - allensdk==2.13.6
   - otter-grader==3.1.4
-  - jupyter-rsession-proxy==2.0.1
 # for exporting notebooks to pdf
   - nbconvert==7.6.0
   - nb2pdf==0.6.2

--- a/deployments/cee/image/environment.yml
+++ b/deployments/cee/image/environment.yml
@@ -5,7 +5,7 @@ channels:
 # Only libraries *not* available in PyPI should be here
 dependencies:
 - python=3.9.*
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 #adding math functionality 
 - matplotlib=3.7.*
 - scipy=1.10.*

--- a/deployments/cee/image/environment.yml
+++ b/deployments/cee/image/environment.yml
@@ -5,6 +5,7 @@ channels:
 # Only libraries *not* available in PyPI should be here
 dependencies:
 - python=3.9.*
+- jupyter-server-proxy==4.1.1
 #adding math functionality 
 - matplotlib=3.7.*
 - scipy=1.10.*

--- a/deployments/data101/image/environment.yml
+++ b/deployments/data101/image/environment.yml
@@ -34,6 +34,7 @@ dependencies:
 - jupyter-archive==3.4.0
 - jupyter-book==0.15.1
 - jupyter-resource-usage==1.0.0
+- jupyter-server-proxy==4.1.1
 - jupyter_bokeh
 - jupyterlab==4.0.11
 - jupyterlab-favorites==3.0.0

--- a/deployments/data101/image/environment.yml
+++ b/deployments/data101/image/environment.yml
@@ -34,7 +34,7 @@ dependencies:
 - jupyter-archive==3.4.0
 - jupyter-book==0.15.1
 - jupyter-resource-usage==1.0.0
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter_bokeh
 - jupyterlab==4.0.11
 - jupyterlab-favorites==3.0.0

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -70,7 +70,7 @@ dependencies:
 
 # data8; foundation
 - datascience==0.17.6
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter-rsession-proxy==2.2.0
 - folium==0.12.1.post1
 

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -70,8 +70,8 @@ dependencies:
 
 # data8; foundation
 - datascience==0.17.6
-- jupyter-server-proxy==3.2.1
-- jupyter-rsession-proxy==2.0.1
+- jupyter-server-proxy==4.1.1
+- jupyter-rsession-proxy==2.2.0
 - folium==0.12.1.post1
 
 # cogsci131; spring 2018

--- a/deployments/dev-r/images/default/environment.yml
+++ b/deployments/dev-r/images/default/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048
 - traitlets=5.9.*
 
-- jupyter-server-proxy==4.0.0
+- jupyter-server-proxy==4.1.1
 - jupyter-rsession-proxy==2.2.0
 
 - syncthing==1.23.5

--- a/deployments/dev-r/images/default/environment.yml
+++ b/deployments/dev-r/images/default/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048
 - traitlets=5.9.*
 
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter-rsession-proxy==2.2.0
 
 - syncthing==1.23.5

--- a/deployments/dev-r/images/secondary/environment.yml
+++ b/deployments/dev-r/images/secondary/environment.yml
@@ -1,7 +1,7 @@
 dependencies:
 - python=3.10
 - pip=23.2.*
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter-rsession-proxy==2.2.0
 - jupyterlab-myst==2.0.2
 - syncthing==1.25.0

--- a/deployments/dev-r/images/secondary/environment.yml
+++ b/deployments/dev-r/images/secondary/environment.yml
@@ -1,7 +1,7 @@
 dependencies:
 - python=3.10
 - pip=23.2.*
-- jupyter-server-proxy==4.1.0
+- jupyter-server-proxy==4.1.1
 - jupyter-rsession-proxy==2.2.0
 - jupyterlab-myst==2.0.2
 - syncthing==1.25.0

--- a/deployments/eecs/image/environment.yml
+++ b/deployments/eecs/image/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.9.*
 - nbclassic==1.0.0
 
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 # Visual Studio Code!
 - jupyter-vscode-proxy=0.1
 - code-server=4.5.2

--- a/deployments/eecs/image/environment.yml
+++ b/deployments/eecs/image/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - python=3.9.*
 - nbclassic==1.0.0
 
+- jupyter-server-proxy==4.1.1
 # Visual Studio Code!
 - jupyter-vscode-proxy=0.1
 - code-server=4.5.2

--- a/deployments/ischool/image/environment.yml
+++ b/deployments/ischool/image/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - jupyter-rsession-proxy==2.2.0
 # https://github.com/berkeley-dsep-infra/datahub/issues/5251
 - nodejs=16 # code-server requires node < 17
+- jupyter-server-proxy==4.1.1
 - jupyter-vscode-proxy==0.5
 - code-server==4.10.1
 # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048

--- a/deployments/ischool/image/environment.yml
+++ b/deployments/ischool/image/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - jupyter-rsession-proxy==2.2.0
 # https://github.com/berkeley-dsep-infra/datahub/issues/5251
 - nodejs=16 # code-server requires node < 17
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter-vscode-proxy==0.5
 - code-server==4.10.1
 # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048

--- a/deployments/julia/image/environment.yml
+++ b/deployments/julia/image/environment.yml
@@ -1,5 +1,5 @@
 dependencies:
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - nodejs==20.8.1
 - pip==22.3.1
 - python==3.10.13

--- a/deployments/julia/image/environment.yml
+++ b/deployments/julia/image/environment.yml
@@ -1,4 +1,5 @@
 dependencies:
+- jupyter-server-proxy==4.1.1
 - nodejs==20.8.1
 - pip==22.3.1
 - python==3.10.13

--- a/deployments/publichealth/image/environment.yml
+++ b/deployments/publichealth/image/environment.yml
@@ -1,7 +1,7 @@
 dependencies:
 - pip
 - syncthing==1.18.6
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter-rsession-proxy==2.2.0
 - pip:
   # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048

--- a/deployments/publichealth/image/environment.yml
+++ b/deployments/publichealth/image/environment.yml
@@ -1,6 +1,7 @@
 dependencies:
 - pip
 - syncthing==1.18.6
+- jupyter-server-proxy==4.1.1
 - jupyter-rsession-proxy==2.2.0
 - pip:
   # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048

--- a/deployments/shiny/image/environment.yml
+++ b/deployments/shiny/image/environment.yml
@@ -3,7 +3,7 @@ dependencies:
 - ipywidgets==8.1.2
 - jupyter-archive==3.4.0
 - jupyter-resource-usage==1.0.1
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter-rsession-proxy==2.2.0
 - jupyter-syncthing-proxy==1.0.3
 - jupyterhub==4.0.2

--- a/deployments/shiny/image/environment.yml
+++ b/deployments/shiny/image/environment.yml
@@ -3,6 +3,7 @@ dependencies:
 - ipywidgets==8.1.2
 - jupyter-archive==3.4.0
 - jupyter-resource-usage==1.0.1
+- jupyter-server-proxy==4.1.1
 - jupyter-rsession-proxy==2.2.0
 - jupyter-syncthing-proxy==1.0.3
 - jupyterhub==4.0.2

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -137,7 +137,7 @@ dependencies:
   - syncthing==1.23.0
   - websockify==0.11.0
 
-  - jupyter-server-proxy==4.1.1
+  - jupyter-server-proxy==4.1.2
   # VS Code support
   - jupyter-vscode-proxy==0.2
   - code-server==4.10.1

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -137,6 +137,7 @@ dependencies:
   - syncthing==1.23.0
   - websockify==0.11.0
 
+  - jupyter-server-proxy==4.1.1
   # VS Code support
   - jupyter-vscode-proxy==0.2
   - code-server==4.10.1

--- a/deployments/stat20/image/environment.yml
+++ b/deployments/stat20/image/environment.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
 - syncthing==1.22.2
+- jupyter-server-proxy==4.1.1
 - jupyter-rsession-proxy==2.2.0
 # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048
 - traitlets=5.9.*

--- a/deployments/stat20/image/environment.yml
+++ b/deployments/stat20/image/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
 - syncthing==1.22.2
-- jupyter-server-proxy==4.1.1
+- jupyter-server-proxy==4.1.2
 - jupyter-rsession-proxy==2.2.0
 # bug w/notebook and traitlets: https://github.com/jupyter/notebook/issues/7048
 - traitlets=5.9.*


### PR DESCRIPTION
Upgrade, and also explicitly add as dependency where this version wouldn't normally be pulled in. Also bump jupyter-rsession-proxy where relevant.