### PR TITLE
Downgrade jupyter-rsession-proxy.

### DIFF
--- a/deployments/biology/image/environment.yml
+++ b/deployments/biology/image/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 
 # proxy web applications
 - jupyter-server-proxy==4.1.2
-- jupyter-rsession-proxy==2.2.0
+- jupyter-rsession-proxy==2.0.1
 
 # Packages from bioconda for IB134L
 # - bwa=0.7.12


### PR DESCRIPTION
biology-staging is exhibiting the /hub/auth 404 behavior unlike our other hubs with the same proxy packages. There's probably another old package lurking which needs to be updated too, but for right now I'll revert to the version that is installed on biology prod.