### PR TITLE
[DH-3] increase cpu allocation for data8 hub and proxy pods

### DIFF
--- a/deployments/data8/config/prod.yaml
+++ b/deployments/data8/config/prod.yaml
@@ -11,7 +11,19 @@ jupyterhub:
       - secretName: tls-cert
         hosts:
           - data8.datahub.berkeley.edu
+  proxy:
+    chp:
+      resources:
+        requests:
+          # Give data101 a lot of guaranteed CPU, prevent 503s?
+          # https://github.com/berkeley-dsep-infra/datahub/issues/2677
+          cpu: 1
   hub:
+    resources:
+      requests:
+        # Give data101 a lot of guaranteed CPU, prevent 503s?
+        # https://github.com/berkeley-dsep-infra/datahub/issues/2677
+        cpu: 1
     db:
       pvc:
         # This also holds logs

--- a/deployments/data8/config/prod.yaml
+++ b/deployments/data8/config/prod.yaml
@@ -15,13 +15,13 @@ jupyterhub:
     chp:
       resources:
         requests:
-          # Give data101 a lot of guaranteed CPU, prevent 503s?
+          # Give data8 a lot of guaranteed CPU, prevent 503s?
           # https://github.com/berkeley-dsep-infra/datahub/issues/2677
           cpu: 1
   hub:
     resources:
       requests:
-        # Give data101 a lot of guaranteed CPU, prevent 503s?
+        # Give data8 a lot of guaranteed CPU, prevent 503s?
         # https://github.com/berkeley-dsep-infra/datahub/issues/2677
         cpu: 1
     db:


### PR DESCRIPTION
data100 hasn't had anywhere nearly as many 503s as data8, and i figured that we could replicate the data100 prod settings and see if that helps.

ref:  https://github.com/berkeley-dsep-infra/datahub/issues/2677