### PR TITLE
[DH-257] Enabling webpdf conversion in Data 100 hub

### DIFF
--- a/deployments/data100/image/environment.yml
+++ b/deployments/data100/image/environment.yml
@@ -53,7 +53,6 @@ dependencies:
   # - jupyter_collaboration==1.0.1
   - jupyterhub==4.0.2
   - nbconvert[webpdf]
-  - pyppeteer==2.0.0
   - pytest-notebook==0.8.1
   - gh-scoped-creds==4.1
   - git+https://github.com/shaneknapp/python-popularity-contest.git@add-error-handling

--- a/deployments/data100/image/postBuild
+++ b/deployments/data100/image/postBuild
@@ -1,0 +1,2 @@
+# install chromium
+pyppeteer-install

--- a/deployments/data100/image/postBuild
+++ b/deployments/data100/image/postBuild
@@ -1,2 +1,5 @@
-# install chromium
-pyppeteer-install
+#!/usr/bin/env bash
+
+export PLAYWRIGHT_BROWSERS_PATH=${CONDA_DIR}
+npm install -g playwright
+playwright install chromium


### PR DESCRIPTION
Changes merged via this PR - https://github.com/berkeley-dsep-infra/datahub/pull/5616 didn't work. Still getting the following error in Data100 hub when I try to export notebook as a webpdf,

``nbconvert failed: No suitable chromium executable found on the system. Please use '--allow-chromium-download' to allow downloading one,or install it using `playwright install chromium``.`

Ref: https://github.com/berkeley-dsep-infra/datahub/pull/5201/commits/95a2587e9562c61bc7fe3b6a9c5273593b304233

