### PR TITLE
[DH-257] Enable webpdf conversion in Data 100 Hub

### DIFF
--- a/deployments/data100/image/environment.yml
+++ b/deployments/data100/image/environment.yml
@@ -53,7 +53,7 @@ dependencies:
   # - jupyter_collaboration==1.0.1
   - jupyterhub==4.0.2
   - nbconvert[webpdf]
-  - pyppeteer==2.0.0
+  #  - pyppeteer==2.0.0
   - pytest-notebook==0.8.1
   - gh-scoped-creds==4.1
   - git+https://github.com/shaneknapp/python-popularity-contest.git@add-error-handling

--- a/deployments/data100/image/postBuild
+++ b/deployments/data100/image/postBuild
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# installing chromium browser to enable webpdf conversion using nbconvert
+export PLAYWRIGHT_BROWSERS_PATH=${CONDA_DIR}
+npm install -g playwright
+playwright install chromium


### PR DESCRIPTION
Changes merged via this PR - https://github.com/berkeley-dsep-infra/datahub/pull/5616 didn't work. Still getting the following error in Data100 hub when I try to export notebook as a webpdf,

nbconvert failed: No suitable chromium executable found on the system. Please use '--allow-chromium-download' to allow downloading one,or install it using `playwright install chromium.`

