### PR TITLE
squelch dependabot alerts for astro and datahub

### DIFF
--- a/deployments/astro/image/environment.yml
+++ b/deployments/astro/image/environment.yml
@@ -51,7 +51,7 @@ dependencies:
   - seaborn>=0.11.2
   - bqplot>=0.12.31
   - astroquery>=0.4.5
-  - astropy>=5.3.3
+  - astropy==5.3.3
   - dustmaps>=1.0.9
   - pyvo>=1.2
   - joblib==1.2.0

--- a/deployments/datahub/images/default/requirements.txt.disabled
+++ b/deployments/datahub/images/default/requirements.txt.disabled
@@ -53,7 +53,7 @@ opencv-python==4.6.0.66
 
 # astr 128/256; spring 2021
 astroquery==0.4.6
-astropy==5.1
+astropy==5.3.3
 dustmaps==1.0.9
 george==0.4.0
 exoplanet==0.5.2


### PR DESCRIPTION
dependabot is complaining about a disabled requirements.txt, so i'd rather just fix that version just in case.

it's also complaining about the astropy version for the astro hub, so i explicitly pinned it to 5.3.3