### PR TITLE
[DH-266] Demog data event will be using datahub instead of workshop hub

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -195,6 +195,23 @@ jupyterhub:
             mountPath: /home/jovyan/ugba-88
             subPath: _shared/course/ugba-88
             readOnly: true
+      # Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
+      course::1534506::enrollment_type::teacher:
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/demog-dataevent-readwrite
+            subPath: _shared/course/demog-dataevent
+      course::1534506::enrollment_type::ta:
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/demog-dataevent-readwrite
+            subPath: _shared/course/demog-dataevent
+      course::1534506::enrollment_type::student:
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/demog-dataevent
+            subPath: _shared/course/demog-dataevent
+            readOnly: true
       course::1530121: # ARE 212, Spring 2024, issue #5278
         mem_limit: 4096M
         mem_guarantee: 4096M
@@ -214,3 +231,6 @@ jupyterhub:
       course::1530164::enrollment_type::teacher:
         mem_limit: 3072M
         mem_guarantee: 3072M
+      course::1534506: #Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
+        mem_limit: 4096M
+        mem_guarantee: 4096M

--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -51,29 +51,3 @@ jupyterhub:
       # As low a guarantee as possible
       guarantee: 128M
       limit: 1G
-  custom:
-    group_profiles:
-      # DataHub Infrastructure staff
-      # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
-      course::1524699::group::all-admins:
-        admin: true
-      # Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
-      course::1534506::enrollment_type::teacher:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/demog-dataevent-readwrite
-            subPath: _shared/course/demog-dataevent
-      course::1534506::enrollment_type::ta:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/demog-dataevent-readwrite
-            subPath: _shared/course/demog-dataevent
-      course::1534506::enrollment_type::student:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/demog-dataevent
-            subPath: _shared/course/demog-dataevent
-            readOnly: true
-      course::1534506: #Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
-        mem_limit: 4096M
-        mem_guarantee: 4096M


### PR DESCRIPTION
Oops, Josh informed that they are planning to use the main datahub for the data event starting April 1st week and workshop hub for the workshop scheduled in June. 