### PR TITLE
remove cummeRbund as we dont need it on datahub

### DIFF
--- a/deployments/datahub/images/default/install.R
+++ b/deployments/datahub/images/default/install.R
@@ -203,6 +203,5 @@ class_libs_install_version("publishing packages", publishing_packages)
 # Bioconductor packages present in rocker images
 # FIXME: Find a way to version these?
 # FIXME: Make sure these are binary installs?
-BiocManager::install("cummeRbund")
 BiocManager::install('rhdf5')
 BiocManager::install('Rhdf5lib')


### PR DESCRIPTION
this PR reverts https://github.com/berkeley-dsep-infra/datahub/pull/5641

see also https://github.com/berkeley-dsep-infra/datahub/issues/5639