### PR TITLE
[DH-269] jupyterhub version bump didn't make it to the hub pods

### DIFF
--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 0.0.1-0.dev.git.7588.h2249f2d4
+version: 0.0.1-0.dev.git.7589.he5fb4865

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1-0.dev.git.7510.h05bfa158
+version: 0.0.1-0.dev.git.7589.he5fb4865
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
...but it made it to the single user servers.  weird.

lets see if re-running `chartpress --push` actually builds the hub image w/the right version of jupyterhub.

fwiw we ARE using the correct helm chart:
![image](https://github.com/berkeley-dsep-infra/datahub/assets/1606572/8a99f530-0210-4a35-8f2e-4c9f5f217a01)

https://github.com/berkeley-dsep-infra/datahub/blob/staging/hub/requirements.yaml#L7