### PR TITLE
[DH-3] tweaking core pool sysctl tcp settings...  again

### DIFF
--- a/vendor/google/gke/node-pool/config/core-pool-sysctl.yaml
+++ b/vendor/google/gke/node-pool/config/core-pool-sysctl.yaml
@@ -24,14 +24,26 @@ linuxConfig:
    #
    # here be dragons.
    #
-   # original values (as of 2023-19-04):
+   # original values (as of 2023-04-19):
    # net.core.netdev_max_backlog=1000
    # net.core.rmem_max=212992
    # net.core.wmem_max=212992
    # net.ipv4.tcp_rmem=4096 87380 6291456
    # net.ipv4.tcp_wmem=4096 16384 4194304
+   #
+   # changes and additional tweaks (2024-04-11):
+   # net.ipv4.tcp_max_syn_backlog=4096
+   # net.core.rmem_max = 3276800
+   # net.core.wmem_max = 3276800
+   # net.ipv4.tcp_rmem = 4096 87380 16777216
+   # net.ipv4.tcp_wmem = 4096 87380 16777216
+   # net.core.somaxconn = 1024
+   #
+   # https://fasterdata.es.net/host-tuning/linux/#toc-anchor-2
    net.core.netdev_max_backlog: '30000'
-   net.core.rmem_max: '3276800'
-   net.core.wmem_max: '3276800'
-   net.ipv4.tcp_rmem: '4096 87380 16777216'
-   net.ipv4.tcp_wmem: '4096 87380 16777216'
+   net.ipv4.tcp_max_syn_backlog: '8192'
+   net.core.rmem_max: '67108864'
+   net.core.wmem_max: '67108864'
+   net.ipv4.tcp_rmem: '4096 87380 33554432'
+   net.ipv4.tcp_wmem: '4096 87380 33554432'
+   net.core.somaxconn: '4096'

--- a/vendor/google/gke/node-pool/config/core-pool-sysctl.yaml
+++ b/vendor/google/gke/node-pool/config/core-pool-sysctl.yaml
@@ -41,9 +41,11 @@ linuxConfig:
    #
    # https://fasterdata.es.net/host-tuning/linux/#toc-anchor-2
    net.core.netdev_max_backlog: '30000'
+   net.core.somaxconn: '4096'
    net.ipv4.tcp_max_syn_backlog: '8192'
+
+   # these values are in bytes
    net.core.rmem_max: '67108864'
    net.core.wmem_max: '67108864'
    net.ipv4.tcp_rmem: '4096 87380 33554432'
    net.ipv4.tcp_wmem: '4096 87380 33554432'
-   net.core.somaxconn: '4096'

--- a/vendor/google/gke/node-pool/config/core-pool-sysctl.yaml
+++ b/vendor/google/gke/node-pool/config/core-pool-sysctl.yaml
@@ -33,11 +33,11 @@ linuxConfig:
    #
    # changes and additional tweaks (2024-04-11):
    # net.ipv4.tcp_max_syn_backlog=4096
-   # net.core.rmem_max = 3276800
-   # net.core.wmem_max = 3276800
-   # net.ipv4.tcp_rmem = 4096 87380 16777216
-   # net.ipv4.tcp_wmem = 4096 87380 16777216
-   # net.core.somaxconn = 1024
+   # net.core.rmem_max=3276800
+   # net.core.wmem_max=3276800
+   # net.ipv4.tcp_rmem=4096 87380 16777216
+   # net.ipv4.tcp_wmem=4096 87380 16777216
+   # net.core.somaxconn=1024
    #
    # https://fasterdata.es.net/host-tuning/linux/#toc-anchor-2
    net.core.netdev_max_backlog: '30000'


### PR DESCRIPTION
after a year, and after seeing more SYN flooding...  as well as reading more and understanding the variables a bit more i wanted to revisit https://github.com/berkeley-dsep-infra/datahub/pull/4488

the big takeaways here are:
1) we have more ram (64G n2-highmem-8 vs 8G n2-standard-8), and should consider allocating a bit more to the kernel for tcp
2) our max number of connections (!!!!) was only 1024 (!?!?!?!).  i increased this to 4096 (somaxconn) which i think might help
3) our nodes look to have lots and lots of bandwidth, so let's take advantage of that!  (https://cloud.google.com/compute/docs/network-bandwidth#egress)

this can safely be merged at any time, and whatever comes out of this PR will be used when we create a new core pool w/more cpu (as 8 cores isn't enough when you run as many hubs as we do on a node) and the same ram.

a bunch of these settings tweaks came from https://fasterdata.es.net/host-tuning/linux/#toc-anchor-2

@ryanlovett @consideRatio @yuvipanda any thoughts?