### PR TITLE
Prevent students from accessing shared data.

### DIFF
--- a/deployments/stat20/config/common.yaml
+++ b/deployments/stat20/config/common.yaml
@@ -86,14 +86,9 @@ jupyterhub:
       course::1524699::group::all-admins:
         admin: true
         mem_limit: 8G
-      # Shared read directory for infra admins to store logs data from every semester
-      course::1524699:
+      # Shared directory to read logs data from every semester
         extraVolumeMounts:
           - name: home
-            mountPath: /home/jovyan/admins-shared-storage
-            subPath: _shared/admins-storage
-    admin:
-      extraVolumeMounts:
-        - name: home
-          mountPath: /opt/shared-readwrite
-          subPath: _shared
+            mountPath: /home/jovyan/admins-shared
+            subPath: _shared-admins
+            readOnly: true


### PR DESCRIPTION
All users can currently read the _shared path, so use a different directory. I've created it on the filestore. Also collapse the course::1524699 group into the existing one, and remove the custom.admin entry. The latter is only needed for pure admins, and we're moving away from that model.

Lastly, the shared storage should be read-only for datahub admins too because we don't want to accidentally edit the log files. If output is generated from this data, it can be saved to datahub admins' home dirs. Admins can upload new data to the filestore without having to go through the hub, so I don't think this will be a problem. An alternative would be to have the path be read-write, but set the modes on the logs to be 444.