### PR TITLE
debump jupyterhub to 3.2.1

### DIFF
--- a/deployments/dev-r/config/staging.yaml
+++ b/deployments/dev-r/config/staging.yaml
@@ -5,8 +5,8 @@ nfsPVC:
 jupyterhub:
   hub:
     image:
-      - name: gcr.io/ucb-datahub-2018/jupyterhub-hub
-        tag: 0.0.1-0.dev.git.7607.h4497642d
+      name: gcr.io/ucb-datahub-2018/jupyterhub-hub
+      tag: 0.0.1-0.dev.git.7126.h64800628
   scheduling:
     userScheduler:
       replicas: 1

--- a/deployments/dev-r/config/staging.yaml
+++ b/deployments/dev-r/config/staging.yaml
@@ -3,6 +3,10 @@ nfsPVC:
     shareName: shares/dev-r/staging
 
 jupyterhub:
+  hub:
+    image:
+      - name: gcr.io/ucb-datahub-2018/jupyterhub-hub
+        tag: 0.0.1-0.dev.git.7607.h4497642d
   scheduling:
     userScheduler:
       replicas: 1


### PR DESCRIPTION
DO NOT MERGE!  this PR is for review and debugging only... i will deploy this locally w/`hubploy`

testing out jupyterhub and nbgitpuller issues in conjunction w/https://github.com/berkeley-dsep-infra/datahub/pull/5693

i set the chart version to 3.2.1, ran `charpress --push` and snagged the image name and tags from there. it didn't actually push anything as those images were already present in the repo.  :)

@ryanlovett @balajialg 