### PR TITLE
[DH-285, 286] Remove/Comment out stanzas enabling elevated privileges and RAM bumps across hubs

### DIFF
--- a/deployments/astro/config/common.yaml
+++ b/deployments/astro/config/common.yaml
@@ -46,18 +46,18 @@ jupyterhub:
         groups:
           - course::1524699::group::astro-admins
       # [DH-270] Astro Lab 128
-      course-staff-1532117:
-        description: Enable course staff to view and access servers.
-        # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1532117
-          - admin:servers!group=course::1532117
-          - access:servers!group=course::1532117
+      #course-staff-1532117:
+      #  description: Enable course staff to view and access servers.
+      #   this role provides permissions to...
+      #  scopes:
+      #    - admin-ui
+      #    - list:users!group=course::1532117
+      #    - admin:servers!group=course::1532117
+      #    - access:servers!group=course::1532117
         # this role will be assigned to...
-        groups:
-          - course::1532117::enrollment_type::teacher
-          - course::1532117::enrollment_type::ta
+      #  groups:
+      #    - course::1532117::enrollment_type::teacher
+      #    - course::1532117::enrollment_type::ta
 
   singleuser:
     extraFiles:

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -33,29 +33,29 @@ jupyterhub:
         groups:
           - course::1524699::group::all-admins
       # Data 100, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5376
-      course-staff-1531798:
-        description: Enable course staff to view and access servers.
+      #course-staff-1531798:
+      #  description: Enable course staff to view and access servers.
         # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1531798
-          - admin:servers!group=course::1531798
-          - access:servers!group=course::1531798
+      #  scopes:
+      #    - admin-ui
+      #    - list:users!group=course::1531798
+      #    - admin:servers!group=course::1531798
+      #    - access:servers!group=course::1531798
         # this role will be assigned to...
-        groups:
-          - course::1531798::group::Admins
+      #  groups:
+      #    - course::1531798::group::Admins
       # Econ 148, Spring 2024, DH-225
-      course-staff-1532866:
-        description: Enable course staff to view and access servers.
+      #course-staff-1532866:
+      #  description: Enable course staff to view and access servers.
         # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1532866
-          - admin:servers!group=course::1532866
-          - access:servers!group=course::1532866
+      #  scopes:
+      #    - admin-ui
+      #    - list:users!group=course::1532866
+      #   - admin:servers!group=course::1532866
+      #    - access:servers!group=course::1532866
         # this role will be assigned to...
-        groups:
-          - course::1532866::group::admin
+      #  groups:
+      #   - course::1532866::group::admin
 
 #  prePuller:
 #    extraImages:
@@ -103,26 +103,15 @@ jupyterhub:
         mem_limit: 4G
 
       # Data 100, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5376
-      course::1531798::group::Content: # Spring 2024 Content Team, ensured 4G RAM
-        mem_limit: 4G
-        mem_guarantee: 4G
+      #course::1531798::group::Content: # Spring 2024 Content Team, ensured 4G RAM
+      #  mem_limit: 4G
+      #  mem_guarantee: 4G
 
       # Data 100, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5376
-      course::1531798::group::Admins: # Spring 2024, Data 100 Admins, ensured 4G RAM
-        mem_limit: 4G
-        mem_guarantee: 4G
-
-      # Econ 148, Spring 2024
-      course::1532866: # Temporarily grant 3G of RAM to all students
-        mem_limit: 3G
-        mem_guarantee: 3G
-
-      # Econ148, Spring '24; testing shared_readwrite for groups in Eric's class
-      course::1532866::group::shared_readwrite:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/_shared-econ148
-            subPath: _shared    
+      #course::1531798::group::Admins: # Spring 2024, Data 100 Admins, ensured 4G RAM
+      #  mem_limit: 4G
+      #  mem_guarantee: 4G
+ 
     admin:
       mem_guarantee: 2G
       extraVolumeMounts:

--- a/deployments/data101/config/common.yaml
+++ b/deployments/data101/config/common.yaml
@@ -94,31 +94,18 @@ jupyterhub:
     config:
     loadRoles:
       # Data 101, SP 2024, #5508
-      course-staff-1532753:
-        description: Enable course staff to view and access servers.
+      #course-staff-1532753:
+      #  description: Enable course staff to view and access servers.
         # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1532753
-          - admin:servers!group=course::1532753
-          - access:servers!group=course::1532753
+      #  scopes:
+      #    - admin-ui
+      #    - list:users!group=course::1532753
+      #    - admin:servers!group=course::1532753
+      #    - access:servers!group=course::1532753
         # this role will be assigned to...
-        groups:
-          - course::1532753::enrollment_type::teacher
-          - course::1532753::enrollment_type::ta
-      # [DH-237] Datahub Security Testing by MICS students
-      course-staff-1534371:
-        description: Enable course staff to view and access servers.
-        # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1534371
-          - admin:servers!group=course::1534371
-          - access:servers!group=course::1534371
-        # this role will be assigned to...
-        groups:
-          - course::1534371::enrollment_type::teacher
-          - course::1534371::enrollment_type::ta
+      #  groups:
+      #    - course::1532753::enrollment_type::teacher
+      #    - course::1532753::enrollment_type::ta
 
   singleuser:
     extraContainers:

--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -49,18 +49,18 @@ jupyterhub:
       #    - course::N::enrollment_type::teacher
       #    - course::N::enrollment_type::ta
       # Data 102, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5437
-      course-staff-1532439:
-        description: Enable course staff to view and access servers.
+      #course-staff-1532439:
+      #  description: Enable course staff to view and access servers.
         # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1532439
-          - admin:servers!group=course::1532439
-          - access:servers!group=course::1532439
+      #  scopes:
+      #    - admin-ui
+      #    - list:users!group=course::1532439
+      #    - admin:servers!group=course::1532439
+      #    - access:servers!group=course::1532439
         # this role will be assigned to...
-        groups:
-          - course::1532439::enrollment_type::teacher
-          - course::1532439::enrollment_type::ta
+      #  groups:
+      #    - course::1532439::enrollment_type::teacher
+      #    - course::1532439::enrollment_type::ta
 
   singleuser:
     defaultUrl: "/lab"

--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -57,18 +57,18 @@ jupyterhub:
       #    - course::N::enrollment_type::ta
 
       # Data 8, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5358
-      course-staff-1532352:
+      #course-staff-1532352:
       #  description: Enable course staff to view and access servers.
       #  # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1532352
-          - admin:servers!group=course::1532352
-          - access:servers!group=course::1532352
+      #  scopes:
+      #    - admin-ui
+      #    - list:users!group=course::1532352
+      #    - admin:servers!group=course::1532352
+      #    - access:servers!group=course::1532352
       #  # this role will be assigned to...
-        groups:
-          - course::1532352::enrollment_type::teacher
-          - course::1532352::enrollment_type::ta
+      #  groups:
+      #    - course::1532352::enrollment_type::teacher
+      #    - course::1532352::enrollment_type::ta
 
   singleuser:
     extraFiles:

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -36,33 +36,6 @@ jupyterhub:
         groups:
           - course::1524699::group::all-admins
 
-      # Stat 165, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5428
-      course-staff-1533482:
-        description: Enable course staff to view and access servers.
-        # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1533482
-          - admin:servers!group=course::1533482
-          - access:servers!group=course::1533482
-        # this role will be assigned to...
-        groups:
-          - course::1533482::enrollment_type::teacher
-          - course::1533482::enrollment_type::ta
-      # [DH-237] Datahub Security Testing by MICS students
-      course-staff-1534371:
-        description: Enable course staff to view and access servers.
-        # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1534371
-          - admin:servers!group=course::1534371
-          - access:servers!group=course::1534371
-        # this role will be assigned to...
-        groups:
-          - course::1534371::enrollment_type::teacher
-          - course::1534371::enrollment_type::ta
-
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2023-12-21
     initContainers:
@@ -161,40 +134,7 @@ jupyterhub:
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
         admin: true
-      # MBA 247, Fall 2023
-      course::1524846::enrollment_type::teacher:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/mba-247-readwrite
-            subPath: _shared/course/mba-247
-      course::1524846::enrollment_type::ta:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/mba-247-readwrite
-            subPath: _shared/course/mba-247
-      course::1524846::enrollment_type::student:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/mba-247
-            subPath: _shared/course/mba-247
-            readOnly: true
-      # UGBA 88, Fall 2023
-      course::1524680::enrollment_type::teacher:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/ugba-88-readwrite
-            subPath: _shared/course/ugba-88
-      course::1524680::enrollment_type::ta:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/ugba-88-readwrite
-            subPath: _shared/course/ugba-88
-      course::1524680::enrollment_type::student:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/ugba-88
-            subPath: _shared/course/ugba-88
-            readOnly: true
+
       # Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
       course::1534506::enrollment_type::teacher:
         extraVolumeMounts:
@@ -212,25 +152,7 @@ jupyterhub:
             mountPath: /home/jovyan/demog-dataevent
             subPath: _shared/course/demog-dataevent
             readOnly: true
-      course::1530121: # ARE 212, Spring 2024, issue #5278
-        mem_limit: 4096M
-        mem_guarantee: 4096M
-      course::1531172: # ENVECON 153, Spring 2024, issue #5279
-        mem_limit: 4096M
-        mem_guarantee: 4096M
-      course::1531929: # Econ/Demog 175, Spring 2024, issue #5447
-        mem_limit: 4096M
-        mem_guarantee: 4096M
-      course::1532145: # Legal Studies 123, Sp24 issue #5530
-        mem_limit: 4096M
-        mem_guarantee: 4096M
-      course::1524699: # datahub infra staff
-        mem_limit: 4096M
-        mem_guarantee: 4096M
-      # Econ 144, Spring 2024, DH 260
-      course::1530164::enrollment_type::teacher:
-        mem_limit: 3072M
-        mem_guarantee: 3072M
+
       course::1534506: #Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
         mem_limit: 8192M
         mem_guarantee: 8192M

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -50,19 +50,7 @@ jupyterhub:
         # this role will be assigned to...
         groups:
           - course::1524699::group::eecs-admins
-      # [DH-237] Datahub Security Testing by MICS students
-      course-staff-1534371:
-        description: Enable course staff to view and access servers.
-        # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1534371
-          - admin:servers!group=course::1534371
-          - access:servers!group=course::1534371
-        # this role will be assigned to...
-        groups:
-          - course::1534371::enrollment_type::teacher
-          - course::1534371::enrollment_type::ta
+
   singleuser:
     extraEnv:
       # Until https://github.com/betatim/vscode-binder/pull/19 is merged
@@ -105,8 +93,3 @@ jupyterhub:
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
         admin: true
-      course::1532904: # EE120, Spring 2024, issue #5492
-        mem_limit: 4096M
-        mem_guarantee: 4096M
-
-

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -53,15 +53,15 @@ jupyterhub:
       course-staff-1533557:
       #  description: Enable course staff to view and access servers.
         # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1533557
-          - admin:servers!group=course::1533557
-          - access:servers!group=course::1533557
+       # scopes:
+       #  - admin-ui
+       #  - list:users!group=course::1533557
+       #  - admin:servers!group=course::1533557
+       #  - access:servers!group=course::1533557
         # this role will be assigned to...
-        groups:
-          - course::1533557::enrollment_type::teacher
-          - course::1533557::enrollment_type::ta
+       # groups:
+        #  - course::1533557::enrollment_type::teacher
+        #  - course::1533557::enrollment_type::ta
 
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2023-12-21

--- a/deployments/publichealth/config/common.yaml
+++ b/deployments/publichealth/config/common.yaml
@@ -39,18 +39,18 @@ jupyterhub:
           - course::1524699::group::all-admins
 
       # PHW 142, Spring 2024, #5368
-      course-staff-1532521:
-        description: Enable course staff to view and access servers.
+      #course-staff-1532521:
+      #  description: Enable course staff to view and access servers.
         # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1532521
-          - admin:servers!group=course::1532521
-          - access:servers!group=course::1532521
+      #  scopes:
+      #    - admin-ui
+      #    - list:users!group=course::1532521
+      #    - admin:servers!group=course::1532521
+      #    - access:servers!group=course::1532521
         # this role will be assigned to...
-        groups:
-          - course::1532521::enrollment_type::teacher
-          - course::1532521::enrollment_type::ta
+      #  groups:
+      #    - course::1532521::enrollment_type::teacher
+      #    - course::1532521::enrollment_type::ta
 
     extraConfig:
       # Use 1x-<title> in `common.yaml` extraConfig values.

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -44,19 +44,6 @@ jupyterhub:
         # this role will be assigned to...
         groups:
           - course::1524699::group::all-admins
-      # Pol Sci 3, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5562
-      course-staff-1531263:
-        description: Enable course staff to view and access servers.
-        # this role provides permissions to...
-        scopes:
-          - admin-ui
-          - list:users!group=course::1531263
-          - admin:servers!group=course::1531263
-          - access:servers!group=course::1531263
-        # this role will be assigned to...
-        groups:
-          - course::1531263::enrollment_type::teacher
-          - course::1531263::enrollment_type::ta
 
   singleuser:
     extraFiles:


### PR DESCRIPTION
**To be merged during maintenance window**

I have removed the stanza for generic hubs (datahub and R hub). For remaining hubs, I have commented out the stanza as they most likely will be repurposed.