### PR TITLE
[DH-276] update cluster switchover doc

### DIFF
--- a/docs/admins/howto/clusterswitch.md
+++ b/docs/admins/howto/clusterswitch.md
@@ -68,14 +68,20 @@ One special thing to note: our `prometheus` instance uses a persistent volume th
 ## Manually deploy a hub to staging
 Finally, we can attempt to deploy a hub to the new cluster!  Any hub will do, but we should start with a low-traffic hub (eg:  https://dev.datahub.berkeley.edu).
 
-First, check the hub's configs for any node pools that need updating.  Typically, this is just the core pool.  After this is done, add the changes to your feature branch (but don't push).  After that, deploy a hub manually:
+First, check the hub's configs for any node pools that need updating.  Typically, this is just the core pool.
+
+Second, update `hubploy.yaml` for this hub and point it to the new cluster you've created.
+
+After this is done, add the changes to your feature branch (but don't push).  After that, deploy a hub manually:
 
 		hubploy deploy dev hub staging
 
 When the deploy is done, visit that hub and confirm that things are working.
 
 ## Manually deploy remaining hubs to staging and prod
-Now, update the remaining hubs' configs to point to the new core pool and use `hubploy` to deploy them to staging as with the previous step.  The easiest way to do this is to have a list of hubs in a text file, and iterate over it with a `for` loop:
+Now, update the remaining hubs' configs to point to the new node pools and `hubploy.yaml` to the cluster.
+
+Then use `hubploy` to deploy them to staging as with the previous step.  The easiest way to do this is to have a list of hubs in a text file, and iterate over it with a `for` loop:
 
 		for x in $(cat hubs.txt); do hubploy deploy ${x} hub staging; done
 		for x in $(cat hubs.txt); do hubploy deploy ${x} hub prod; done

--- a/docs/admins/howto/clusterswitch.md
+++ b/docs/admins/howto/clusterswitch.md
@@ -104,6 +104,9 @@ Now you can finally push your changes to github.  Create a PR, merge to `staging
 
 Create another PR to merge to `prod` and that deploy should work just fine.
 
+## Update log and billing sinks, BigQuery queries, etc.
+I would recommend searching GCP console for all occurrences of the old cluster name, and fixing any bits that might be left over.  This should only take a few minutes, but should definitely be done.
+
 FIN!
 
 ## Deleting the old cluster

--- a/docs/admins/howto/clusterswitch.md
+++ b/docs/admins/howto/clusterswitch.md
@@ -45,8 +45,8 @@ The [calendar autoscaler](https://docs.datahub.berkeley.edu/en/latest/admins/how
 
 		kubectl create namespace node-placeholder
 
-## Create a new static endpoint IP and switch DNS to point our new deployment at it.
-1. Create a new static endpoint IP in the [GCP console](https://console.cloud.google.com/networking/addresses/add?project=ucb-datahub-2018).
+## Create a new static IP and switch DNS to point our new deployment at it.
+1. Create a new static IP in the [GCP console](https://console.cloud.google.com/networking/addresses/add?project=ucb-datahub-2018).
 2. Open [infoblox](https://infoblox.net.berkeley.edu) and change the wildcard and empty entries for datahub.berkeley.edu to point to the IP from the previous step.
 3. Update `support/values.yaml`, under `ingress-nginx` with the newly created IP from infoblox:  `loadBalancerIP: xx.xx.xx.xx`.
 4. Add and commit this change to your feature branch (still do not push).

--- a/docs/admins/howto/clusterswitch.md
+++ b/docs/admins/howto/clusterswitch.md
@@ -1,8 +1,10 @@
 # Switching over a hub to a new cluster
 
-This document describes how to switch an existing hub to a new cluster.  The example used here refers to the data8x hub.
+This document describes how to switch an existing hub to a new cluster.  The example used here refers to moving all UC Berkeley Datahubs.
 
-## Make a new cluster
+You might find it easier to switch to a new cluster if you're running a [very old k8s version](https://cloud.google.com/kubernetes-engine/docs/release-notes), or in lieu of performing a [cluster credential rotation](https://cloud.google.com/kubernetes-engine/docs/how-to/credential-rotation).
+
+## Create a new cluster
 1. Create a new cluster using the specifications here:  
    https://docs.datahub.berkeley.edu/en/latest/admins/cluster-config.html
 2. Set up helm on the cluster according to the instructions here:  

--- a/docs/admins/howto/clusterswitch.md
+++ b/docs/admins/howto/clusterswitch.md
@@ -65,16 +65,26 @@ One special thing to note: our `prometheus` instance uses a persistent volume th
 		  storageClass: ssd
 		  existingClaim: prometheus-data-2024-05-15
 
-## Manually deploy a hub
+## Manually deploy a hub to staging
 Finally, we can attempt to deploy a hub to the new cluster!  Any hub will do, but we should start with a low-traffic hub (eg:  https://dev.datahub.berkeley.edu).
 
+First, check the hub's configs for any node pools that need updating.  Typically, this is just the core pool.  After this is done, add the changes to your feature branch (but don't push).  After that, deploy a hub manually:
 
 		hubploy deploy dev hub staging
 
 When the deploy is done, visit that hub and confirm that things are working.
 
-## Update CircleCI
+## Manually deploy remaining hubs to staging
+Now, update the remaining hubs' configs to point to the new core pool and use `hubploy` to deploy them to staging as with the previous step.  The easiest way to do this is to have a list of hubs in a text file, and iterate over it with a `for` loop:
 
+		for x in $(cat hubs.txt); do hubploy deploy ${x} hub staging; done
+
+When done, add the modified configs to your feature branch (and again, don't push yet).
+
+## Update CircleCI
+Once you've successfully deployed the clusters manually via `hubploy`, it's time to update CircleCI to point to the new cluster.
+
+All you need to do is `grep` for the old cluster name in `.circleci/config.yaml` and change this to the name of the new cluster.  There should just be four entries:  two for the `gcloud get credentials <cluster-name>`, and two in comments.  Make these changes and add them to your existing feature branch, but don't commit yet.
 
 ## Switch staging over to new cluster
 1. Change the name of the cluster in hubploy.yaml to match the name you chose when creating your new cluster.

--- a/docs/admins/howto/clusterswitch.md
+++ b/docs/admins/howto/clusterswitch.md
@@ -47,10 +47,9 @@ The [calendar autoscaler](https://docs.datahub.berkeley.edu/en/latest/admins/how
 
 ## Create a new static endpoint IP and switch DNS to point our new deployment at it.
 1. Create a new static endpoint IP in the [GCP console](https://console.cloud.google.com/networking/addresses/add?project=ucb-datahub-2018).
-2. Grab the new endpoint:  `gcloud container clusters describe <CLUSTER_NAME> --region us-central1 | grep ^endpoint`
-3. Open [infoblox](https://infoblox.net.berkeley.edu) and change the wildcard and empty entries for datahub.berkeley.edu to point to the IP from the previous step.
-4. Update `support/values.yaml`, under `ingress-nginx` with the newly created IP from infoblox:  `loadBalancerIP: xx.xx.xx.xx`.
-5. Add and commit this change to your feature branch (still do not push).
+2. Open [infoblox](https://infoblox.net.berkeley.edu) and change the wildcard and empty entries for datahub.berkeley.edu to point to the IP from the previous step.
+3. Update `support/values.yaml`, under `ingress-nginx` with the newly created IP from infoblox:  `loadBalancerIP: xx.xx.xx.xx`.
+4. Add and commit this change to your feature branch (still do not push).
 
 You will re-deploy the support chart in the next step.
 

--- a/docs/admins/howto/clusterswitch.md
+++ b/docs/admins/howto/clusterswitch.md
@@ -2,7 +2,7 @@
 
 This document describes how to switch an existing hub to a new cluster.  The example used here refers to moving all UC Berkeley Datahubs.
 
-You might find it easier to switch to a new cluster if you're running a [very old k8s version](https://cloud.google.com/kubernetes-engine/docs/release-notes), or in lieu of performing a [cluster credential rotation](https://cloud.google.com/kubernetes-engine/docs/how-to/credential-rotation).
+You might find it easier to switch to a new cluster if you're running a [very old k8s version](https://cloud.google.com/kubernetes-engine/docs/release-notes), or in lieu of performing a [cluster credential rotation](https://cloud.google.com/kubernetes-engine/docs/how-to/credential-rotation).  Sometimes starting from scratch is easier than an iterative and potentially destructive series of operations.
 
 ## Create a new cluster
 1. Create a new cluster using the specifications here:  


### PR DESCRIPTION
update our cluster switchover docs to something relevant, recent and (mostly) complete.

at some point, i'd love for this doc to be used as a template for a "how to deploy our infra from zero to datahub".