### PR TITLE
[DH-252] Increase RAM to 12 GB for Stat 20 admins to help run quarto dashboard with SP 24 logs

### DIFF
--- a/deployments/stat20/config/common.yaml
+++ b/deployments/stat20/config/common.yaml
@@ -85,7 +85,7 @@ jupyterhub:
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
         admin: true
-        mem_limit: 8G
+        mem_limit: 12G
       # Shared directory to read logs data from every semester
         extraVolumeMounts:
           - name: home


### PR DESCRIPTION
As discussed during the sprint planning meeting
