### PR TITLE
[DH-299] Install jupyterlab extension published in pypi

### DIFF
--- a/deployments/a11y/config/common.yaml
+++ b/deployments/a11y/config/common.yaml
@@ -53,5 +53,5 @@ jupyterhub:
         pvcName: home-nfs-v3
         subPath: "{username}"
     memory:
-      guarantee: 512M
-      limit: 1G
+      guarantee: 3G
+      limit: 3G

--- a/deployments/a11y/image/environment.yml
+++ b/deployments/a11y/image/environment.yml
@@ -35,6 +35,7 @@ dependencies:
   - nbconvert-a11y==2023.12.6
   - nb2pdf==0.6.2
   - nbpdfexport==0.2.1
+  - jupyterlab-a11y-checker==0.1.1
   # ###
   # The items below are from infra-requirements, however lab conflicts with the
   # alpha notebook.

--- a/deployments/a11y/image/postBuild
+++ b/deployments/a11y/image/postBuild
@@ -8,8 +8,8 @@ npm install -g pa11y@6.2.3
 
 # Install Node.js and Yarn for DH-299
 echo "Installing Node.js and Yarn..."
-sudo apt-get update && sudo apt-get install -y nodejs npm
-sudo npm install -g yarn
+apt-get update && apt-get install -y nodejs npm
+npm install -g yarn
 
 # Clone the JupyterLab extension repository
 EXTENSION_GIT_REPO="https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker.git"

--- a/deployments/a11y/image/postBuild
+++ b/deployments/a11y/image/postBuild
@@ -5,35 +5,3 @@ set -eux
 
 npm install -g pa11y-ci@3.1.0
 npm install -g pa11y@6.2.3
-
-# Install Node.js and Yarn for DH-299
-echo "Installing Node.js and Yarn..."
-apt-get update && apt-get install -y nodejs npm
-npm install -g yarn
-
-# Clone the JupyterLab extension repository
-EXTENSION_GIT_REPO="https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker.git"
-EXTENSION_NAME="jupyterlab-a11y-checker"
-echo "Cloning the JupyterLab extension repository..."
-git clone $EXTENSION_GIT_REPO
-
-# Navigate to the extension directory
-cd $EXTENSION_NAME
-
-# Install the extension using yarn
-echo "Installing the JupyterLab extension..."
-yarn install
-yarn build
-
-# Install the extension in JupyterLab
-jupyter labextension install .
-
-# Rebuild JupyterLab to include the new extension
-echo "Rebuilding JupyterLab..."
-jupyter lab build
-
-# Clean up
-cd ..
-rm -rf $EXTENSION_NAME
-
-echo "JupyterLab extension installed successfully!"

--- a/deployments/a11y/image/postBuild
+++ b/deployments/a11y/image/postBuild
@@ -5,3 +5,35 @@ set -eux
 
 npm install -g pa11y-ci@3.1.0
 npm install -g pa11y@6.2.3
+
+# Install Node.js and Yarn for DH-299
+echo "Installing Node.js and Yarn..."
+sudo apt-get update && sudo apt-get install -y nodejs npm
+sudo npm install -g yarn
+
+# Clone the JupyterLab extension repository
+EXTENSION_GIT_REPO="https://github.com/berkeley-dsep-infra/jupyterlab-a11y-checker.git"
+EXTENSION_NAME="jupyterlab-a11y-checker"
+echo "Cloning the JupyterLab extension repository..."
+git clone $EXTENSION_GIT_REPO
+
+# Navigate to the extension directory
+cd $EXTENSION_NAME
+
+# Install the extension using yarn
+echo "Installing the JupyterLab extension..."
+yarn install
+yarn build
+
+# Install the extension in JupyterLab
+jupyter labextension install .
+
+# Rebuild JupyterLab to include the new extension
+echo "Rebuilding JupyterLab..."
+jupyter lab build
+
+# Clean up
+cd ..
+rm -rf $EXTENSION_NAME
+
+echo "JupyterLab extension installed successfully!"


### PR DESCRIPTION
Since https://github.com/berkeley-dsep-infra/datahub/pull/5743 didn't work. Trying a new approach to install the extension in the hub (thanks @ryanlovett)