### PR TITLE
Increase a11y hub RAM to 3 GB for extension testing purposes

### DIFF
--- a/deployments/a11y/config/common.yaml
+++ b/deployments/a11y/config/common.yaml
@@ -53,5 +53,5 @@ jupyterhub:
         pvcName: home-nfs-v3
         subPath: "{username}"
     memory:
-      guarantee: 512M
-      limit: 1G
+      guarantee: 3G
+      limit: 3G


### PR DESCRIPTION
Since #5767 build is failing. I am trying to do the installation in a11y hub and the manual build process requires more RAM. Temporarily, increasing the RAM for a11y hub.