### PR TITLE
Install git from conda-forge.

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -9,6 +9,9 @@ dependencies:
 - syncthing==1.18.6
 - nbclassic==1.0.0
 
+# gh-scoped-creds needs a newer version of git than what jammy provides
+- git==2.45.1
+
 # pymc3 needs this
 - mkl-service=2.4.*
 


### PR DESCRIPTION
Jammy's git is too old to support gh-scoped-creds, so install from conda-forge.