### PR TITLE
Bump memory for admins.

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -133,7 +133,8 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
+        mem_limit: 2048M
+        mem_guarantee: 2048M
 
       # Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
       course::1534506::enrollment_type::teacher:


### PR DESCRIPTION
mamba/conda is starting to consume more than 1G for simple package installs. Bump memory for admins at least, so that we have some headrooms.

Also remove `admin` since that is safely replaced by a discrete role. ("datahub-staff")