### PR TITLE
removing errant space in data100 config

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -43,7 +43,7 @@ jupyterhub:
           - access:servers!group=course::1535115
         # this role will be assigned to...
         groups:
-          - course:: 1535115::group::Admins
+          - course::1535115::group::Admins
       # Econ 148, Spring 2024, DH-225
       #course-staff-1532866:
       #  description: Enable course staff to view and access servers.


### PR DESCRIPTION
fixes https://github.com/berkeley-dsep-infra/datahub/pull/5803
resolves https://github.com/berkeley-dsep-infra/datahub/issues/5802

fwiw, i ran `yamllint` and it didn't catch the errant space in the config.