### PR TITLE
Assign enhanced privilege to Data 100 course staff based on enrollment type instead of group

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -43,7 +43,8 @@ jupyterhub:
           - access:servers!group=course::1535115
         # this role will be assigned to...
         groups:
-          - course::1535115::group::Admins
+          - course::1535115::enrollment_type::teacher
+          - course::1535115::enrollment_type::ta
       # Econ 148, Spring 2024, DH-225
       #course-staff-1532866:
       #  description: Enable course staff to view and access servers.


### PR DESCRIPTION
To address this [comment](https://github.com/berkeley-dsep-infra/datahub/issues/5802#issuecomment-2181853716) 

Yaml linter says the config is good.
<img width="995" alt="Screenshot 2024-06-20 at 9 09 26 PM" src="https://github.com/berkeley-dsep-infra/datahub/assets/2306166/0b9fde9f-0723-4200-a7e6-bde7526d696c">

