### PR TITLE
Making node-pools command more general & match to clusters command

### DIFF
--- a/docs/admins/cluster-config.rst
+++ b/docs/admins/cluster-config.rst
@@ -56,7 +56,7 @@ the currently favored configuration.
         --disk-size=200 --disk-type=pd-balanced \
         --no-enable-autoupgrade \
         --tags=hub-cluster \
-        --cluster=spring-2024 \
+        --cluster=<cluster-name> \
         user-<pool-name>-<yyyy>-<mm>-<dd>
 
 

--- a/docs/admins/cluster-config.rst
+++ b/docs/admins/cluster-config.rst
@@ -25,6 +25,8 @@ A ``gcloud container clusters create`` command can succintly express the
 configuration of our kubernetes cluster. The following command represents
 the currently favored configuration.
 
+This creates the GKE cluster. It may host one or more node pools:
+
 .. code:: bash
 
    gcloud container clusters create \
@@ -41,6 +43,8 @@ the currently favored configuration.
         --create-subnetwork="" \
         --tags=hub-cluster \
         <cluster-name>
+
+Here's how we add a node pool to the cluster, beyond the default pool:
 
 .. code:: bash
 


### PR DESCRIPTION
I want to get the specific, current production cluster name out of the second sample command (the `gcloud container node-pools create` command). This also matches the fill-in-the-blank syntax `<cluster-name>` in the immediately-previous `gcloud container clusters create` command.

Better to have the second command error out on the placeholder name rather than unintentionally deploying the new node pool in the `spring-2024` cluster when not intended.