### PR TITLE
adding a yamllint config cribbed from 2i2c

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,45 @@
+# This config represents running the command `yamllint -d relaxed .` with the
+# following extra rules:
+#
+# new-line-at-end-of-file:
+#   level: warning
+# trailing-spaces:
+#   level: warning
+#
+# We also ignore the cookiecutter directories as these often contain
+# jinja-style templating functions that yamllint doesn't play nicely with
+#
+# cribbed from https://github.com/2i2c-org/infrastructure/blob/main/.yamllint.yaml
+---
+extends: default
+
+ignore: |
+  **/template/**
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length: disable
+  new-line-at-end-of-file:
+    level: warning
+  trailing-spaces:
+    level: warning
+  truthy: disable


### PR DESCRIPTION
i cribbed this from https://github.com/2i2c-org/infrastructure/blob/main/.yamllint.yaml

yammlint should be run the following way: `yamllint -d relaxed `.
