### PR TITLE
add postBuild to the Dockerfile

### DIFF
--- a/deployments/dev/images/default/Dockerfile
+++ b/deployments/dev/images/default/Dockerfile
@@ -125,7 +125,11 @@ RUN R -e "IRkernel::installspec(user = FALSE, prefix='${CONDA_DIR}')"
 
 # clear out /tmp
 USER root
+COPY postBuild /tmp/postBuild
+RUN chmod +x /tmp/postBuild
+RUN /tmp/postBuild
 RUN rm -rf /tmp/*
+
 
 USER ${NB_USER}
 WORKDIR /home/${NB_USER}

--- a/deployments/dev/images/default/postBuild
+++ b/deployments/dev/images/default/postBuild
@@ -13,7 +13,7 @@ wget https://github.com/ollama/ollama/releases/download/v0.1.48/ollama-linux-amd
 chmod +x /usr/local/bin/ollama
 
 # Run the phi3:mini model with the specified data directory
-/usr/local/bin/ollama run phi3:mini --data-dir $OLLAMA_DATA_DIR
+# /usr/local/bin/ollama run phi3:mini --data-dir $OLLAMA_DATA_DIR
 
 # Run the tinyllama model with the specified data directory
-/usr/local/bin/ollama run tinyllama --data-dir $OLLAMA_DATA_DIR
+# /usr/local/bin/ollama run tinyllama --data-dir $OLLAMA_DATA_DIR


### PR DESCRIPTION
you need to explicitly add postBuild to the Dockerfile for repo2docker to know to build it.

@balajialg 

i tested this out on my desktop and the build will fail with `Error: unknown flag: --data-dir`.