### PR TITLE
Data 6: Increase RAM to 2 GB & provide enhanced privileges for course staff

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -22,7 +22,7 @@ jupyterhub:
     loadRoles:
       # datahub staff
       datahub-staff:
-       # description: Enable admin for datahub staff
+        description: Enable admin for datahub staff
         # this role provides permissions to...
         scopes:
           - admin-ui

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -22,7 +22,7 @@ jupyterhub:
     loadRoles:
       # datahub staff
       datahub-staff:
-        description: Enable admin for datahub staff
+       # description: Enable admin for datahub staff
         # this role provides permissions to...
         scopes:
           - admin-ui
@@ -35,6 +35,20 @@ jupyterhub:
         # this role will be assigned to...
         groups:
           - course::1524699::group::all-admins
+
+      # Data 6, Summer 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5847
+      course-staff-1535590:
+      #  description: Enable course staff to view and access servers.
+      #  # this role provides permissions to...
+        scopes:
+          - admin-ui
+          - list:users!group=course::1535590
+          - admin:servers!group=course::1535590
+          - access:servers!group=course::1535590
+      #  # this role will be assigned to...
+        groups:
+          - course::1535590::enrollment_type::teacher
+          - course::1535590::enrollment_type::ta
 
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2024-05-08
@@ -144,6 +158,10 @@ jupyterhub:
             subPath: _shared/course/demog-dataevent
             readOnly: true
 
-      course::1534506: #Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
+      course::1534506: # Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
         mem_limit: 8192M
         mem_guarantee: 8192M
+
+      course::1535590: # Data 6, https://github.com/berkeley-dsep-infra/datahub/issues/5847
+        mem_limit: 2048M
+        mem_guarantee: 2048M


### PR DESCRIPTION
It should resolve #5847 and #5849. Checked the config with a 3rd party yaml linter. Fingers crossed about CI linter 


![Screenshot 2024-07-09 at 11 22 27 AM](https://github.com/berkeley-dsep-infra/datahub/assets/2306166/7c7189bd-27a4-40b4-8fd1-0426d0312643)
