### PR TITLE
rolling back dependabot changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ jupyter-repo2docker==2024.3.0
 myst-parser
 chardet
 # requests==2.31.0
-requests==2.32.3
-urllib3==2.2.2
+requests<2.29.0
+urllib3<2.0


### PR DESCRIPTION
we seem to be having issues on staging.datahub after this was merged:  https://github.com/berkeley-dsep-infra/datahub/pull/5832

this pr rolls back the root `requirements.txt` changes.  hopefully this fixes things but there's something significantly 'not right' going on here regardless.