### PR TITLE
[DH-227] fixing python linter errors

### DIFF
--- a/deployments/biology/image/patches/ncbiquery.py
+++ b/deployments/biology/image/patches/ncbiquery.py
@@ -403,7 +403,8 @@ class NCBITaxa(object):
                 subtree = prepostorder[start:end+1]
             except ValueError:
                 # If root taxid is not found in postorder, must be a tip node
-            	subtree = [root_taxid]
+                subtree = [root_taxid]
+
             leaves = set([v for v, count in Counter(subtree).items() if count == 1])
             nodes[root_taxid] = PhyloTree(name=str(root_taxid))
             current_parent = nodes[root_taxid]

--- a/deployments/biology/image/patches/ncbiquery.py
+++ b/deployments/biology/image/patches/ncbiquery.py
@@ -175,7 +175,7 @@ class NCBITaxa(object):
             result = _db.execute(cmd)
             try:
                 taxid, spname, score = result.fetchone()
-            except:
+            except Exception:
                 pass
             else:
                 taxid = int(taxid)
@@ -299,7 +299,7 @@ class NCBITaxa(object):
 
         query = ','.join(['"%s"' %n for n in six.iterkeys(name2origname)])
         cmd = 'select spname, taxid from species where spname IN (%s)' %query
-        result = self.db.execute('select spname, taxid from species where spname IN (%s)' %query)
+        result = self.db.execute(cmd)
         for sp, taxid in result.fetchall():
             oname = name2origname[sp.lower()]
             name2id.setdefault(oname, []).append(taxid)
@@ -395,15 +395,12 @@ class NCBITaxa(object):
             root_taxid = int(list(taxids)[0])
             with open(self.dbfile+".traverse.pkl", "rb") as CACHED_TRAVERSE:
                 prepostorder = pickle.load(CACHED_TRAVERSE)
-            descendants = {}
-            found = 0
             nodes = {}
-            hit = 0
             visited = set()            
             start = prepostorder.index(root_taxid)
             try:
-            	end = prepostorder.index(root_taxid, start+1)
-            	subtree = prepostorder[start:end+1]
+                end = prepostorder.index(root_taxid, start+1)
+                subtree = prepostorder[start:end+1]
             except ValueError:
                 # If root taxid is not found in postorder, must be a tip node
             	subtree = [root_taxid]
@@ -663,7 +660,6 @@ def load_ncbi_tree_from_dump(tar):
     name2node = {}
     node2taxname = {}
     synonyms = set()
-    name2rank = {}
     node2common = {}
     print("Loading node names...")
     for line in tar.extractfile("names.dmp"):

--- a/deployments/data8/image/ipython_config.py
+++ b/deployments/data8/image/ipython_config.py
@@ -1,3 +1,3 @@
 # Disable history manager, we don't really use it
 # and by default it puts an sqlite file on NFS, which is not something we wanna do
-c.HistoryManager.enabled = False
+c.HistoryManager.enabled = False # noqa: F821

--- a/deployments/edx/image/ipython_config.py
+++ b/deployments/edx/image/ipython_config.py
@@ -1,3 +1,3 @@
 # Disable history manager, we don't really use it
 # and by default it puts an sqlite file on NFS, which is not something we wanna do
-c.HistoryManager.enabled = False
+c.HistoryManager.enabled = False # noqa: F821

--- a/images/node-placeholder-scaler/scaler/scaler.py
+++ b/images/node-placeholder-scaler/scaler/scaler.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import logging
-import datetime
 import argparse
 import tempfile
 import subprocess
@@ -54,15 +53,16 @@ def get_replica_counts(events):
             pools_replica_config = None
             try:
                 pools_replica_config = yaml.load(ev.description)
-            except:
+            except Exception as e:
+                logging.error(f"Caught unhandled exception parsing event description:\n{e}")
                 logging.error(f"Error in parsing description of {_event_repr(ev)}")
                 logging.error(f"{ev.description=}")
                 pass
             if pools_replica_config is None:
                 logging.error(f"No description in event {_event_repr(ev)}")
                 continue
-            elif type(pools_replica_config) == str:
-                logging.error(f"Event description not parsed as dictionary.")
+            elif isinstance(pools_replica_config, str):
+                logging.error("Event description not parsed as dictionary.")
                 logging.error(f"{ev.description=}")
                 continue
             for pool_name, count in pools_replica_config.items():

--- a/scripts/delete-unused-users.py
+++ b/scripts/delete-unused-users.py
@@ -142,7 +142,7 @@ def main(args):
     and if so, delete them!
     """
     if args.credentials and args.hub_url:
-        logger.error(f"Please use only one of --hub_url or --credentials options when executing the script.")
+        logger.error("Please use only one of --hub_url or --credentials options when executing the script.")
         raise
 
     if args.hub_url:

--- a/scripts/git-pre-cloner.py
+++ b/scripts/git-pre-cloner.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os
-import sys
 import string
 import subprocess
 
@@ -27,6 +26,7 @@ def git_clone():
         return
     out = subprocess.check_output(['git', 'clone', args.repo],
             cwd=local_repo).decode('utf-8')
+    return out
 
 def copy_repo(username):
     safe = safe_username(username)
@@ -34,10 +34,14 @@ def copy_repo(username):
     source_dir = os.path.join(local_repo, repo_dirname)
     dest_dir = os.path.join(home_dir, repo_dirname)
     if os.path.exists(dest_dir):
-        if args.verbose: print('Skipping {}'.format(safe))
+        if args.verbose:
+            print('Skipping {}'.format(safe))
     else:
-        if args.verbose: print(safe)
+        if args.verbose:
+            print(safe)
         out = subprocess.check_output(['cp', '-a', source_dir, dest_dir])
+        return out
+    return
 
 # main
 parser = argparse.ArgumentParser(description='Pre-clone course assets.')
@@ -54,13 +58,16 @@ repo_dirname = os.path.basename(args.repo).split('.')[0]
 if not os.path.exists(local_repo):
     os.mkdir(local_repo)
 
-git_clone()
+out = git_clone()
+if args.verbose:
+    print(out)
 
 f = open(args.filename)
 line = f.readline()
 while line != '':
     email = line.strip()
-    if '@berkeley.edu' not in email: continue # just in case
+    if '@berkeley.edu' not in email:
+        continue # just in case
     username = email.split('@')[0]
     copy_repo(username)
     line = f.readline()


### PR DESCRIPTION
i'm using `ruff` to lint...  here's what it caught:

```
deployments/biology/image/patches/ncbiquery.py:178:13: E722 Do not use bare `except`
deployments/biology/image/patches/ncbiquery.py:301:9: F841 Local variable `cmd` is assigned to but never used
deployments/biology/image/patches/ncbiquery.py:398:13: F841 Local variable `descendants` is assigned to but never used
deployments/biology/image/patches/ncbiquery.py:399:13: F841 Local variable `found` is assigned to but never used
deployments/biology/image/patches/ncbiquery.py:401:13: F841 Local variable `hit` is assigned to but never used
deployments/biology/image/patches/ncbiquery.py:666:5: F841 Local variable `name2rank` is assigned to but never used
deployments/data8/image/ipython_config.py:3:1: F821 Undefined name `c`
deployments/edx/image/ipython_config.py:3:1: F821 Undefined name `c`
images/node-placeholder-scaler/scaler/scaler.py:3:8: F401 [*] `datetime` imported but unused
images/node-placeholder-scaler/scaler/scaler.py:57:13: E722 Do not use bare `except`
images/node-placeholder-scaler/scaler/scaler.py:64:18: E721 Do not compare types, use `isinstance()`
images/node-placeholder-scaler/scaler/scaler.py:65:31: F541 [*] f-string without any placeholders
scripts/delete-unused-users.py:145:22: F541 [*] f-string without any placeholders
scripts/git-pre-cloner.py:5:8: F401 [*] `sys` imported but unused
scripts/git-pre-cloner.py:28:5: F841 Local variable `out` is assigned to but never used
scripts/git-pre-cloner.py:37:24: E701 Multiple statements on one line (colon)
scripts/git-pre-cloner.py:39:24: E701 Multiple statements on one line (colon)
scripts/git-pre-cloner.py:40:9: F841 Local variable `out` is assigned to but never used
scripts/git-pre-cloner.py:63:36: E701 Multiple statements on one line (colon)
```

