### PR TITLE
[DH-319] Add ESPM 157 specific packages and enable gh-scoped-creds config

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -106,6 +106,8 @@ jupyterhub:
         hub.jupyter.org/pool-name: core-pool-2024-05-08
   singleuser:
     extraEnv:
+      GH_SCOPED_CREDS_CLIENT_ID: Iv23ct7Qx1mAotaIIYx9
+      GH_SCOPED_CREDS_APP_URL: https://github.com/apps/berkeley-datahub-git-access
       # Unset NotebookApp from hub/values. Necessary for recent lab versions.
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
     nodeSelector:

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -217,3 +217,10 @@ dependencies:
   # [DH-243] https://github.com/berkeley-dsep-infra/datahub/issues/5571, Legal Studies 123, Spring 24
   - geopandas==0.14.3
   - rtree==1.2.0
+
+  # [DH-319] https://github.com/berkeley-dsep-infra/datahub/issues/5827, 
+  - altair==5.3.0
+  - ibis-framework==9.2.0
+  - leafmap==0.36.1
+  - mystmd==1.3.0
+  - jupyterlab-git==0.50.1


### PR DESCRIPTION
- Hubployed gh-scoped-creds config changes to staging hub and it works as expected
- repo2docker is building the image locally but it is taking a huge amount of time. So, pushing the changes now as I am signing off from work.

Ref: 
https://github.com/berkeley-dsep-infra/datahub/issues/5826
https://github.com/berkeley-dsep-infra/datahub/issues/5827
https://github.com/berkeley-dsep-infra/datahub/issues/5513


