### PR TITLE
Replacing ibis-framework python package with ibis-framework[pandas]

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -220,7 +220,7 @@ dependencies:
 
   # [DH-319] https://github.com/berkeley-dsep-infra/datahub/issues/5827, ESPM 157
   - altair==5.3.0
-  - ibis-pandas==9.2.0
+  - ibis-framework[pandas]==9.2.0
   - leafmap==0.36.1
   - mystmd==1.3.0
   - jupyterlab-git==0.50.1

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -218,9 +218,9 @@ dependencies:
   - geopandas==0.14.3
   - rtree==1.2.0
 
-  # [DH-319] https://github.com/berkeley-dsep-infra/datahub/issues/5827, 
+  # [DH-319] https://github.com/berkeley-dsep-infra/datahub/issues/5827, ESPM 157
   - altair==5.3.0
-  - ibis-framework==9.2.0
+  - ibis-pandas==9.2.0
   - leafmap==0.36.1
   - mystmd==1.3.0
   - jupyterlab-git==0.50.1


### PR DESCRIPTION
So, I tested the following [notebook](https://github.com/espm-157/climate-python-template/blob/main/climate.ipynb) from ESPM 157 Github repo in Datahub-staging and realized that the package they need to get the notebook cells to execute successfully is ibis-pandas instead of ibis-framework. I have reached out to Carl via https://github.com/berkeley-dsep-infra/datahub/issues/5827#issuecomment-2251320530 to gain clarity about removing ibis-framework package.

https://pypi.org/project/ibis-framework/