### PR TITLE
[DH-340 and 341] Add jupyter_app_launcher and jupyter-cache packages to dashboard image in Dev hub

### DIFF
--- a/deployments/dev/images/secondary/environment.yml
+++ b/deployments/dev/images/secondary/environment.yml
@@ -8,6 +8,8 @@ dependencies:
 - python==3.11.*
 - git==2.39.1
 - jupyterhub==4.1.5
+- jupyter_app_launcher==0.2.1
+- jupyter-cache==1.0.0
 - jupyter-resource-usage==1.0.0
 - jupyterlab==4.0.11
 - jupyterlab-favorites==3.0.0


### PR DESCRIPTION
To help intern Sophie visualize usage analysis notebook as a voila dashboard,

https://jira-secure.berkeley.edu/browse/DH-341
https://jira-secure.berkeley.edu/browse/DH-340

https://anaconda.org/conda-forge/jupyter-cache
https://anaconda.org/conda-forge/jupyter_app_launcher

FYI, image built locally!
