### PR TITLE
debumping labeler for now

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4


### PR DESCRIPTION
apparently v5 has breaking changes when moving from earlier versions.  will need to read the docs before doing this again...

ref:  https://github.com/actions/labeler#notes-regarding-pull_request_target-event