### PR TITLE
[DH-358] Commenting out jupyterlab-myst extension in datahub image!

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -232,6 +232,6 @@ dependencies:
 
   # [DH-319] https://github.com/berkeley-dsep-infra/datahub/issues/5827, ESPM 157
   - ibis-framework[pandas,duckdb]==9.2.0
- # - jupyterlab_myst==2.4.2 (Causing issues with rendering of the latex output
+ # - jupyterlab_myst==2.4.2 (Causing issues with rendering of the latex output for a CEE course)
 
   # ATTEMPT TO PUT NEW PACKAGES IN THE CONDA LIST ABOVE FIRST, RATHER THAN PIP

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -232,6 +232,6 @@ dependencies:
 
   # [DH-319] https://github.com/berkeley-dsep-infra/datahub/issues/5827, ESPM 157
   - ibis-framework[pandas,duckdb]==9.2.0
-  - jupyterlab_myst==2.4.2
+ # - jupyterlab_myst==2.4.2 (Causing issues with rendering of the latex output
 
   # ATTEMPT TO PUT NEW PACKAGES IN THE CONDA LIST ABOVE FIRST, RATHER THAN PIP


### PR DESCRIPTION
This is causing issues to rendering of latex output which is needed for another civil engineering course. For context - https://jira-secure.berkeley.edu/browse/DH-358