### PR TITLE
[DH-359] bumping seaborn

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -168,8 +168,8 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        mem_limit: 2048M
-        mem_guarantee: 2048M
+        mem_limit: 4096M
+        mem_guarantee: 4096M
 
       # Demog Data Event, April 1 - Sep 30, https://github.com/berkeley-dsep-infra/datahub/issues/5643
       course::1534506::enrollment_type::teacher:

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - pandas==2.2.2
 - statsmodels=0.13.5
 - scikit-learn=1.4.*
-- seaborn=0.11.*
+- seaborn=0.13.2
 # - bokeh=2.3.*
 - decorator=5.0.*
 - networkx=2.6.*


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DH-359

In addition to bumping seaborn, I'm also bumping the RAM for admins cuz 2GB was not enough for mamba install/upgrade to succeed and being able to do that for testing is quite useful.