### PR TITLE
[DH-301] fixing workflow to test again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -799,14 +799,6 @@ workflows:
             branches:
               only:
                 - prod
-  deploy-node-placeholder:
-    jobs:
-      - deploy-node-placeholder:
-          filters:
-            branches:
-              # We don't have staging / prod for our node placeholder pods
-              # So we deploy only when deploying staging
-              only: staging
 
   deploy-support:
     jobs:

--- a/.github/workflows/deploy-node-placeholder.yaml
+++ b/.github/workflows/deploy-node-placeholder.yaml
@@ -74,7 +74,7 @@ jobs:
           sops -d -i deployments/datahub/secrets/gke-key.json
           gcloud auth \
             activate-service-account \
-            --key-file deployments/datahub/secrets/gke-key.json \
+            --key-file deployments/datahub/secrets/gke-key.json
           gcloud container clusters \
             --region=us-central1 --project=ucb-datahub-2018 \
             get-credentials spring-2024

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -143,7 +143,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 29247442944
-    replicas: 1
+    replicas: 0
   dlab:
     nodeSelector:
       hub.jupyter.org/pool-name: dlab-pool


### PR DESCRIPTION
found an extra `\` which caused the `gcloud` command(s) to fail, as well as remove an errant node-placeholder workflow left over in `.circleci/config.yaml`