### PR TITLE
[DH-301] hopefully fixing bash arrays + parsing

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -37,8 +37,8 @@ jobs:
             # deploy any hubs that have been labeled for deployment
             for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
               if [[ "$label" == hub-* ]]; then
-                label=$(echo $label | awk -F'-' '{print $2}')
-                HUBS+="$label"
+                hub_name=$(echo $label | awk -F'-' '{print $2}')
+                HUBS+="$hub_name "
                 echo "DEPLOY=1" >> $GITHUB_ENV
               fi
             done
@@ -119,11 +119,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check out the image repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
-
       - name: Pull out any hubs that need deploying from the labels on the merge commit to prod
         run: |
           echo "PR labels: ${{ steps.pr-labels.outputs.labels }}"
@@ -137,13 +132,19 @@ jobs:
             # deploy any hubs that have been labeled for deployment
             for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
               if [[ "$label" == hub-* ]]; then
-                label=$(echo $label | awk -F'-' '{print $2}')
-                HUBS+="$label"
+                hub_name=$(echo $label | awk -F'-' '{print $2}')
+                HUBS+="$hub_name "
                 echo "DEPLOY=1" >> $GITHUB_ENV
               fi
             done
             echo "DEPLOY_HUBS=${HUBS[@]}" >> $GITHUB_ENV
           fi
+
+      - name: Check out the image repo
+        if: ${{ env.DEPLOY }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
 
       - name: Setup python
         if: ${{ env.DEPLOY }}


### PR DESCRIPTION
after checking out the results/execution logs of one of the new github workflows (https://github.com/berkeley-dsep-infra/datahub/actions/runs/10584196501/job/29327903196) i noticed that the hub names to deploy weren't properly being added to the array i defined called `HUBS`:

![image](https://github.com/user-attachments/assets/9b784ad0-460d-4a1a-a284-2381dc507aeb)

this is odd, and i even tested locally and it *should* have properly populated the list:

```
(dh) ➜  workflows git:(more-bash-logic-shennanigans) ✗ a=(); a+="asdf"; a+="fdas"; echo $a
asdf fdas
```

so...  i think the extra space in this expression will force things to work:  `HUB+="$hub "

however, this is a sign that i think we should NOT use bash for stuff like this and instead have some small python helper scripts that will at least behave in an expected way.