### PR TITLE
Add admins to workshop hub

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -27,6 +27,14 @@ jupyterhub:
       JupyterHub:
         admin_access: false
         authenticator_class: dummy
+      Authenticator:
+        admin_users:
+          # infrastructure
+          - rylo
+          - sknapp
+          - felder
+          - balajialwar
+          - gmerritt
   proxy:
     chp:
       nodeSelector:


### PR DESCRIPTION
For some reason, no infra admin has admin access to the workshop hub. Reviewing this issue - https://github.com/berkeley-dsep-infra/datahub/issues/6032 made me realize that.

Stanza ref: https://github.com/berkeley-dsep-infra/datahub/blob/97feaa0c0ad999875909c3d8d8150fdfb9db2d38/deployments/publichealth/config/common.yaml#L45C1-L51C24