### PR TITLE
[DH-361] enabling nonempty directory delete

### DIFF
--- a/deployments/nature/config/common.yaml
+++ b/deployments/nature/config/common.yaml
@@ -35,6 +35,11 @@ jupyterhub:
           - course::1524699::group::all-admins
   singleuser:
     extraFiles:
+      jupyter_server_config.json:
+        mountPath: /usr/local/etc/jupyter/jupyter_server_config.json
+        data:
+          FileContentsManager:
+            always_delete_dir: true
       remove-exporters:
         mountPath: /etc/jupyter/jupyter_notebook_config.py
         stringData: |


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DH-361 #5827 

Looks to me like show hidden files is enabled by default now.

```
(notebook) jovyan@jupyter-felder:~$ cat /usr/local/etc/jupyter/jupyter_server_config.json 
{"ContentsManager":{"allow_hidden":true},"FileContentsManager":{"always_delete_dir":true}}
(notebook) jovyan@jupyter-felder:~$ 
```
