### PR TITLE
Adding more tools  in python for dashboarding to the dashboard image

### DIFF
--- a/deployments/dev/images/secondary/environment.yml
+++ b/deployments/dev/images/secondary/environment.yml
@@ -39,3 +39,10 @@ dependencies:
 # Install voila and voici for generating voila dashboards
 - voila==0.5.7
 - voici==0.6.1
+# Adding more data tools to make this image comprehensive
+- dash==2.17.1
+- bokeh==3.4.0
+- panel==1.4.5
+- datashader==0.16.3
+- streamlit=1.38.0
+#- jupyter-containds=0.2.2


### PR DESCRIPTION
I am hoping that the dashboard image provides comprehensive suite of tools for dashboarding and acts as a test bed for piloting dashboarding tools. So, I have added some of the common data viz tools used by data folks to the image. 

https://quansight.com/post/dash-voila-panel-streamlit-our-thoughts-on-the-big-four-dashboarding-tools/
https://streamlit.io/components?category=graphs
https://medium.com/@marcskovmadsen/i-prefer-to-use-panel-for-my-data-apps-here-is-why-1ff5d2b98e8f
https://panel.holoviz.org/how_to/index.html#build-apps