### PR TITLE
Increase RAM to 16 GB and CPU allocation to 2 cores for Data 100 teaching staff

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -112,10 +112,13 @@ jupyterhub:
         admin: true
         mem_limit: 4G
 
-      # Data 100, Spring 2024, https://github.com/berkeley-dsep-infra/datahub/issues/5376
-      #course::1531798::group::Admins: # Spring 2024, Data 100 Admins, ensured 4G RAM
-      #  mem_limit: 4G
-      #  mem_guarantee: 4G
+      # Data 100, Fall 2024, https://github.com/berkeley-dsep-infra/datahub/issues/6167
+      course::1537664::enrollment_type::teacher: # Fall 2024, Data 100 Instructors, ensured 16G RAM
+        mem_limit: 16G
+        mem_guarantee: 16G
+      course::1537664::enrollment_type::ta: # Fall 2024, Data 100 TAs, ensured 16G RAM
+        mem_limit: 16G
+        mem_guarantee: 16G
     admin:
       mem_guarantee: 2G
       extraVolumeMounts:

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -116,9 +116,13 @@ jupyterhub:
       course::1537664::enrollment_type::teacher: # Fall 2024, Data 100 Instructors, ensured 16G RAM
         mem_limit: 16G
         mem_guarantee: 16G
+        cpu_limit: 2
+        cpu_guarantee: 2
       course::1537664::enrollment_type::ta: # Fall 2024, Data 100 TAs, ensured 16G RAM
         mem_limit: 16G
         mem_guarantee: 16G
+        cpu_limit: 2
+        cpu_guarantee: 2
     admin:
       mem_guarantee: 2G
       extraVolumeMounts:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DH-381

This PR increases resources for teaching staff to test the homework 3 before releasing. Increasing CPU and RAM for students will be a separate PR

Ref: https://github.com/berkeley-dsep-infra/datahub/issues/6167
https://github.com/berkeley-dsep-infra/datahub/issues/6168