### PR TITLE
[DH-301] parens were causing this to quietly fail

### DIFF
--- a/.github/scripts/determine-hub-deployments.py
+++ b/.github/scripts/determine-hub-deployments.py
@@ -18,10 +18,8 @@ def main(args):
     hubs = []
 
     # Deploy all hubs by getting deployment names from the dirs in deployments/
-    if (
-        "GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT" or
-        "GITHUB_PR_LABEL_HUB_IMAGES"
-    ) in os.environ.keys():
+    if "GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT" or \
+        "GITHUB_PR_LABEL_HUB_IMAGES" in os.environ.keys():
         for deployment in next(os.walk(args.deployments))[1]:
             if deployment not in args.ignore:
                 hubs.append(deployment)


### PR DESCRIPTION
the parens in an `if` statement were causing the `GITHUB_PR_LABEL_HUB_IMAGES` env var to be ignored.  this was because they were interpreted as a boolean, instead of a grouping.

if the `GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT` env var existed, things deployed.

before the fix:

```
(dh) ➜  datahub git:(fix-hub-deployment-script) ✗ export GITHUB_PR_LABEL_HUB_IMAGES=1
(dh) ➜  datahub git:(fix-hub-deployment-script) ✗ .github/scripts/determine-hub-deployments.py --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool
(dh) ➜  datahub git:(fix-hub-deployment-script) ✗ 
```

after the parens were removed:

```
(dh) ➜  datahub git:(fix-hub-deployment-script) ✗ export GITHUB_PR_LABEL_HUB_IMAGES=1
(dh) ➜  datahub git:(fix-hub-deployment-script) ✗ .github/scripts/determine-hub-deployments.py --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool
a11y
astro
biology
cee
data101
data102
dev
eecs
gradebook
ischool
julia
logodev
nature
publichealth
shiny
stat159
stat20
ugr01
(dh) ➜  datahub git:(fix-hub-deployment-script) ✗
```