### PR TITLE
[DH-377] bump data101 proxy ram

### DIFF
--- a/deployments/data101/config/common.yaml
+++ b/deployments/data101/config/common.yaml
@@ -17,7 +17,14 @@ jupyterhub:
     chp:
       nodeSelector:
         hub.jupyter.org/pool-name: core-pool-2024-05-08
-
+      resources:
+        requests:
+          # FIXME: We want no guarantees here!!!
+          # This is lowest possible value
+          cpu: 0.001
+          memory: 3Gi
+        limits:
+          memory: 3Gi
   hub:
     config:
     loadRoles:


### PR DESCRIPTION
since they had an outage, mimic the same parameters we use w/datahub, data100 and data8.

we should also consider setting this to 3G for all hubs.