### PR TITLE
[DH-301] new deployment workflow for edx, fix minor typo in base deployer workflow

### DIFF
--- a/.github/scripts/determine-hub-deployments.py
+++ b/.github/scripts/determine-hub-deployments.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
         "--ignore",
         "-i",
         nargs="*",
+        action="extend",
         default=["template"],
         help="Ignore one or more deployment targets."
     )

--- a/.github/workflows/deploy-edx-hub.yaml
+++ b/.github/workflows/deploy-edx-hub.yaml
@@ -85,7 +85,7 @@ jobs:
             helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
             helm repo update
 
-      - name: Deploy hubs to staging
+      - name: Deploy hub to staging
         if: ${{ env.DEPLOY }}
         run: |
           while read deployment; do
@@ -169,7 +169,7 @@ jobs:
             helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
             helm repo update
 
-      - name: Deploy hubs to prod
+      - name: Deploy hub to prod
         if: ${{ env.DEPLOY }}
         run: |
           while read deployment; do

--- a/.github/workflows/deploy-edx-hub.yaml
+++ b/.github/workflows/deploy-edx-hub.yaml
@@ -1,5 +1,5 @@
-# This workflow will determine if the base hub image and/or single-user server
-# image for any or all hubs has changed, and if so, deploy accordingly.
+# This workflow will determine if the edx hub image and/or single-user server
+# image has changed, and if so, deploy accordingly.
 #
 name: Deploy staging and prod hubs
 on:
@@ -20,25 +20,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check for hubs that need deploying from the labels on the merge commit to staging
+      - name: Check edx hub changes that need deploying from the labels on the merge commit to staging
         run: |
           echo "PR labels: ${{ steps.pr-labels.outputs.labels }}"
-          # If the PR labels "hub-images" or "jupyterhub-deployment" are
-          # present, this means the base hub image has changed, and all hubs
-          # (staging or prod) need to be redeployed.
-          #
-          if [[ -n ${GITHUB_PR_LABEL_HUB_IMAGES} || -n ${GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT} ]]; then
-            echo "DEPLOY=1" >> $GITHUB_ENV
-          # Otherwise, check to see if the PR labels contain any hubs, and 
-          # deploy just those hubs to staging.
-          #
-          else
-            for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
-              if [[ "$label" == hub-* ]]; then
-                echo "DEPLOY=1" >> $GITHUB_ENV
-              fi
-            done
-          fi
+          for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
+            if [[ "$label" == hub-edx ]]; then
+              echo "DEPLOY=1" >> $GITHUB_ENV
+            fi
+          done
 
       - name: Check out the image repo
         if: ${{ env.DEPLOY }}
@@ -63,8 +52,8 @@ jobs:
         if: ${{ env.DEPLOY }}
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GKE_KEY }}
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          credentials_json: ${{ secrets.GKE_KEY_EDX }}
+          project_id: ${{ secrets.GCP_PROJECT_ID_EDX }}
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
@@ -103,7 +92,7 @@ jobs:
             echo "Deploying single-user image and hub config to ${deployment}"
             hubploy --verbose deploy --timeout 30m ${deployment} hub staging
             echo
-          done < <(python .github/scripts/determine-hub-deployments.py --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool)
+          done < <(python .github/scripts/determine-hub-deployments.py --only-deploy edx)
 
   deploy-hubs-to-prod:
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'
@@ -115,25 +104,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check for hubs that need deploying from the labels on the merge commit to prod
+      - name: Check edx hub changes that need deploying from the labels on the merge commit to prod
         run: |
           echo "PR labels: ${{ steps.pr-labels.outputs.labels }}"
-          # If the PR labels "hub-images" or "jupyterhub-deployment" are
-          # present, this means the base hub image has changed, and all hubs
-          # (staging or prod) need to be redeployed.
-          #
-          if [[ -n ${GITHUB_PR_LABEL_HUB_IMAGES} || -n ${GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT} ]]; then
-            echo "DEPLOY=1" >> $GITHUB_ENV
-          # Otherwise, check to see if the PR labels contain any hubs, and 
-          # deploy just those hubs to prod.
-          #
-          else
-            for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
-              if [[ "$label" == hub-* ]]; then
-                echo "DEPLOY=1" >> $GITHUB_ENV
-              fi
-            done
-          fi
+          for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
+            if [[ "$label" == hub-edx ]]; then
+              echo "DEPLOY=1" >> $GITHUB_ENV
+            fi
+          done
 
       - name: Check out the image repo
         if: ${{ env.DEPLOY }}
@@ -158,8 +136,8 @@ jobs:
         if: ${{ env.DEPLOY }}
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GKE_KEY }}
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          credentials_json: ${{ secrets.GKE_KEY_EDX }}
+          project_id: ${{ secrets.GCP_PROJECT_ID_EDX }}
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
@@ -198,4 +176,4 @@ jobs:
             echo "Deploying single-user image and hub config to ${deployment}"
             hubploy --verbose deploy --timeout 30m ${deployment} hub prod
             echo
-          done < <(python .github/scripts/determine-hub-deployments.py --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool)
+          done < <(python .github/scripts/determine-hub-deployments.py --only-deploy edx)

--- a/.github/workflows/deploy-edx-hub.yaml
+++ b/.github/workflows/deploy-edx-hub.yaml
@@ -1,7 +1,7 @@
 # This workflow will determine if the edx hub image and/or single-user server
 # image has changed, and if so, deploy accordingly.
 #
-name: Deploy staging and prod hubs
+name: Deploy edx staging and prod hub
 on:
   workflow_dispatch:
   push:
@@ -10,7 +10,7 @@ on:
       - prod
 
 jobs:
-  deploy-hubs-to-staging:
+  deploy-edx-hub-to-staging:
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
     steps:
@@ -94,7 +94,7 @@ jobs:
             echo
           done < <(python .github/scripts/determine-hub-deployments.py --only-deploy edx)
 
-  deploy-hubs-to-prod:
+  deploy-edx-hub-to-prod:
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -103,7 +103,7 @@ jobs:
             echo "Deploying single-user image and hub config to ${deployment}"
             hubploy --verbose deploy --timeout 30m ${deployment} hub staging
             echo
-          done < <(python .github/scripts/determine-hub-deployments.py --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool)
+          done < <(python .github/scripts/determine-hub-deployments.py --ignore edx --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool)
 
   deploy-hubs-to-prod:
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'
@@ -198,4 +198,4 @@ jobs:
             echo "Deploying single-user image and hub config to ${deployment}"
             hubploy --verbose deploy --timeout 30m ${deployment} hub prod
             echo
-          done < <(python .github/scripts/determine-hub-deployments.py --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool)
+          done < <(python .github/scripts/determine-hub-deployments.py --ignore edx --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool)


### PR DESCRIPTION
since edx is running in a different cluster than the rest of the hubs, we need to authenticate to that cluster using `GKE_KEY_EDX` when setting up `google-github-actions/setup-gcloud@v2`.

i would prefer to *not* have two workflows for hub deployment, but i can't think of an elegant way to do this in `deploy-hubs.yaml`.

output of script when ignoring edx:
```
(dh) ➜  datahub git:(workflow-for-edx-deployment) ✗ # this will trigger all hubs to be deployed: GITHUB_PR_LABEL_HUB_IMAGES=1
(dh) ➜  datahub git:(workflow-for-edx-deployment) ✗ # how we currently deploy the hubs that have been ported to the new CI/CD
(dh) ➜  datahub git:(workflow-for-edx-deployment) ✗ GITHUB_PR_LABEL_HUB_IMAGES=1 .github/scripts/determine-hub-deployments.py --ignore edx --only-deploy gradebook logodev shiny stat159 stat20 nature a11y ugr01 data101 astro biology cee dev publichealth eecs julia data102 ischool
a11y
astro
biology
cee
data101
data102
dev
eecs
gradebook
ischool
julia
logodev
nature
publichealth
shiny
stat159
stat20
ugr01
(dh) ➜  datahub git:(workflow-for-edx-deployment) ✗ # and if we only want to deploy edx even if the env var declares "deploy them all"!
(dh) ➜  datahub git:(workflow-for-edx-deployment) ✗ GITHUB_PR_LABEL_HUB_IMAGES=1 .github/scripts/determine-hub-deployments.py --only-deploy edx
edx
```