### PR TITLE
[DH-301] comment out gcloud action login, remove edx deploy from staging

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -58,12 +58,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Auth to gcloud
-        if: ${{ env.DEPLOY }}
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GKE_KEY }}
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
+#      - name: Auth to gcloud
+#        if: ${{ env.DEPLOY }}
+#        uses: google-github-actions/auth@v2
+#        with:
+#          credentials_json: ${{ secrets.GKE_KEY }}
+#          project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
@@ -102,7 +102,7 @@ jobs:
             echo "Deploying single-user image and hub config to ${deployment}"
             hubploy --verbose deploy --timeout 30m ${deployment} hub staging
             echo
-          done < <(python .github/scripts/determine-hub-deployments.py --ignore edx)
+          done < <(python .github/scripts/determine-hub-deployments.py)
 
   deploy-hubs-to-prod:
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'


### PR DESCRIPTION
since we rely on hubploy to auth itself, let's try removing the `google-github-actions/auth@v2` action.