### PR TITLE
[DH-301] remove gcloud auth stanza as its superfluous

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -58,13 +58,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-#      - name: Auth to gcloud
-#        if: ${{ env.DEPLOY }}
-#        uses: google-github-actions/auth@v2
-#        with:
-#          credentials_json: ${{ secrets.GKE_KEY }}
-#          project_id: ${{ secrets.GCP_PROJECT_ID }}
-
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
         uses: google-github-actions/setup-gcloud@v2
@@ -152,13 +145,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Auth to gcloud
-        if: ${{ env.DEPLOY }}
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GKE_KEY }}
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
         uses: google-github-actions/setup-gcloud@v2
@@ -196,4 +182,4 @@ jobs:
             echo "Deploying single-user image and hub config to ${deployment}"
             hubploy --verbose deploy --timeout 30m ${deployment} hub prod
             echo
-          done < <(python .github/scripts/determine-hub-deployments.py --ignore edx)
+          done < <(python .github/scripts/determine-hub-deployments.py)


### PR DESCRIPTION
i had a hunch that we were trying to auth multiple times, so let's remove that stanza and allow hubploy to do the auth for us.

tested in https://github.com/berkeley-dsep-infra/datahub/pull/6277

i will also add another tag to this to ensure that deploying to other non-edx hubs still works.