### PR TITLE
Enable shared directories for data100 based on bcourses id

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -116,18 +116,18 @@ jupyterhub:
       course::1537664::enrollment_type::teacher:
         extraVolumeMounts:
           - name: home
-            mountPath: /home/jovyan/data-100-readwrite
-            subPath: _shared/course/data-100
+            mountPath: /home/jovyan/data100-shared-readwrite
+            subPath: _shared/course/data100-shared-readwrite
       course::1537664::enrollment_type::ta:
         extraVolumeMounts:
           - name: homes
-            mountPath: /home/jovyan/data-100-readwrite
-            subPath: _shared/course/data-100
+            mountPath: /home/jovyan/data100-shared-readwrite
+            subPath: _shared/course/data100-shared-readwrite
       course::1537664::enrollment_type::student:
         extraVolumeMounts:
           - name: home
-            mountPath: /home/jovyan/data-100-shared
-            subPath: _shared/course/data-100
+            mountPath: /home/jovyan/data100-shared
+            subPath: _shared/course/data100-shared
             readOnly: true
     admin:
       mem_guarantee: 2G

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -111,6 +111,24 @@ jupyterhub:
       course::1524699::group::all-admins:
         admin: true
         mem_limit: 4G
+
+      # Data C100, Fall 2024, https://github.com/berkeley-dsep-infra/datahub/issues/6316
+      course::1537664::enrollment_type::teacher:
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/data-100-readwrite
+            subPath: _shared/course/data-100
+      course::1537664::enrollment_type::ta:
+        extraVolumeMounts:
+          - name: homes
+            mountPath: /home/jovyan/data-100-readwrite
+            subPath: _shared/course/data-100
+      course::1537664::enrollment_type::student:
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/data-100-shared
+            subPath: _shared/course/data-100
+            readOnly: true
     admin:
       mem_guarantee: 2G
       extraVolumeMounts:


### PR DESCRIPTION
Even though Data 100 already has a shared directory, I thought it would be good to enable the bcourses-based workflow for creating shared directories. Students who are no longer affiliated with the course at the end of the semester won't have access to the shared directory.

Created `data100-shared-readwrite` and `data100-shared` directories in NFS server

Ref: https://github.com/berkeley-dsep-infra/datahub/issues/6316