### PR TITLE
[DH-301] forgot to modify data102 hubploy.yaml

### DIFF
--- a/deployments/data102/hubploy.yaml
+++ b/deployments/data102/hubploy.yaml
@@ -2,12 +2,6 @@ images:
   images:
     - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/data102-user-image:1ae8a9184467
 
-  registry:
-    provider: gcloud
-    gcloud:
-      project: ucb-datahub-2018
-      service_key: gcr-key.json
-
 cluster:
   provider: gcloud
   gcloud:


### PR DESCRIPTION
i was preparing to do some work to move our GCR images to GAR, and noticed that i'd missed the hubploy for data102