### PR TITLE
Fix typo in data 100 shared dir configs!

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -120,7 +120,7 @@ jupyterhub:
             subPath: _shared/course/data100-shared-readwrite
       course::1537664::enrollment_type::ta:
         extraVolumeMounts:
-          - name: homes
+          - name: home
             mountPath: /home/jovyan/data100-shared-readwrite
             subPath: _shared/course/data100-shared-readwrite
       course::1537664::enrollment_type::student:


### PR DESCRIPTION
I hubployed the changes to data100-staging and was able to spawn the TA's server and access shared directory - `data100-shared-readwrite`.

The changes have been hubployed to data100 prod and waiting for the TA to confirm that they can spawn the server and access the shared directory. We can merge the PR changes to prod post TA's confirmation.  Sigh - I wish this caught my eye during the commit :(