### PR TITLE
[DH-301] fix dev hub's `hubploy.yaml`

### DIFF
--- a/deployments/dev/hubploy.yaml
+++ b/deployments/dev/hubploy.yaml
@@ -1,7 +1,3 @@
-# you will also need to update config/common.yaml to include the following for
-# the secondary image tag:
-# kubespawner_override:
-#   image: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/dev-secondary-image:df11f4f1caa1
 images:
   images:
     - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/dev-primary-image:6000a5694eab


### PR DESCRIPTION
the helpful comments would actually break the commit/pull request creation, which is dumb and just uses `grep` and `sed`.  the full path to the image in the comment would be the first hit when grepping that file and then `sed` would fail.

i discovered this when testing if the way of doing this would work if i tweaked the for loop in https://github.com/berkeley-dsep-infra/hub-user-image-template/pull/22

needless to say, sometimes helpful comments are sometimes not that helpful.  :)