### PR TITLE
[DH-377] Increase ephemeral ports by default

### DIFF
--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 20240731-224556.git.8734.h9b451d16
+version: 20240731-224556.git.8735.h3e417283

--- a/hub/Chart.yaml
+++ b/hub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: hub
-version: 20240731-224556.git.8607.hf7abb041
+version: 20240731-224556.git.8734.h9b451d16

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -39,6 +39,16 @@ jupyterhub:
       # https://github.com/Jimbly/http-proxy-node16/commit/56283e33edfc7aad8c2605dd493da8a196b4371d
       # https://github.com/consideRatio/configurable-http-proxy/commits/main/
       # https://jira-secure.berkeley.edu/browse/DH-382 timeouts break stuff
+      #
+      # bump the default ip_local_port_range from "32768 60999" to "10000 65000"
+      # https://z2jh.jupyter.org/en/latest/resources/reference.html#proxy-chp-extrapodspec
+      # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+      # 
+      extraPodSpec:
+        securityContext:
+          sysctls: 
+            name: "net.ipv4.ip_local_port_range"
+            value: "10000 65000"
       image:
         tag: 4.6.2
       # extraCommandLineFlags:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -44,12 +44,12 @@ jupyterhub:
       # https://z2jh.jupyter.org/en/latest/resources/reference.html#proxy-chp-extrapodspec
       # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
       #
-      extraPodSpec:
+      #extraPodSpec:
         # why u fail?
-        securityContext:
-          sysctls:
-            name: "net.ipv4.ip_local_port_range"
-            value: "10000 65001"
+      #  securityContext:
+      #    sysctls:
+      #      name: "net.ipv4.ip_local_port_range"
+      #      value: "10000 65001"
       image:
         tag: 4.6.2
       # extraCommandLineFlags:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -44,12 +44,11 @@ jupyterhub:
       # https://z2jh.jupyter.org/en/latest/resources/reference.html#proxy-chp-extrapodspec
       # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
       #
-      #extraPodSpec:
-        # why u fail?
-      #  securityContext:
-      #    sysctls:
-      #      name: "net.ipv4.ip_local_port_range"
-      #      value: "10000 65001"
+      extraPodSpec:
+        securityContext:
+          sysctls:
+          - name: net.ipv4.ip_local_port_range
+            value: "10000 65000"
       image:
         tag: 4.6.2
       # extraCommandLineFlags:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -45,10 +45,11 @@ jupyterhub:
       # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
       #
       extraPodSpec:
+        # why u fail?
         securityContext:
           sysctls:
             name: "net.ipv4.ip_local_port_range"
-            value: "10000 65000"
+            value: "10000 65001"
       image:
         tag: 4.6.2
       # extraCommandLineFlags:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -43,10 +43,10 @@ jupyterhub:
       # bump the default ip_local_port_range from "32768 60999" to "10000 65000"
       # https://z2jh.jupyter.org/en/latest/resources/reference.html#proxy-chp-extrapodspec
       # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
-      # 
+      #
       extraPodSpec:
         securityContext:
-          sysctls: 
+          sysctls:
             name: "net.ipv4.ip_local_port_range"
             value: "10000 65000"
       image:

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 20240731-224556.git.8652.h618d172c
+version: 20240731-224556.git.8735.h3e417283
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 20240731-224556.git.8610.hedc17750
+version: 20240731-224556.git.8652.h618d172c
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: us-central1-docker.pkg.dev/ucb-datahub-2018/core/node-placeholder-scaler
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "20240731-224556.git.8610.hedc17750"
+  tag: "20240731-224556.git.8652.h618d172c"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
instead of manually patching proxy pods that run out of ephemeral ports in a terrible game of whack-a-mole, just give every hub's chp more ports by default.

it's a band-aid for https://github.com/jupyterhub/configurable-http-proxy/issues/557, and while it doesn't fix the problem outright it definitely lessens the impact significantly.

instead of ~15-45m of "503 service unavailable" being presented to the users when we hit the default limit of 28231 ephemeral ports (60999 - 32768), we give ourselves 55000 ephemeral ports (65000 - 10000).  this limits downtime to a few minutes of high hub response times, and possibly a few users seeing 503.

we haven't seen any impact on other services, and remain slightly optimistic of it's efficacy in smoothing out the road.

we've also given the worst impacted chp pods 3G of ram each, but could also consider scaling that down to 2.5G.  under max load, when the port count is ~32000, the chp pod ram usage is typically between ~1.2-1.6G.

i will test this on logodev.d.b.e