### PR TITLE
[DH-377] bump default tcp available port range

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -44,6 +44,11 @@ jupyterhub:
       # https://z2jh.jupyter.org/en/latest/resources/reference.html#proxy-chp-extrapodspec
       # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
       #
+      extraPodSpec:
+        securityContext:
+          sysctls:
+          - name: net.ipv4.ip_local_port_range
+            value: "10000 65000"
       image:
         tag: 4.6.2
       # extraCommandLineFlags:


### PR DESCRIPTION
DO NOT MERGE (yet)

before merging, we will need to edit the proxy deployment configs for nature, bio, data101, data100, data8, and datahub to remove the initContainers stanza.

after that is done, we should (carefully) test this by manually deploying to one of those hubs.  if things are working properly, deploy and test a 2nd hub.  if that works, then merge this PR.