### PR TITLE
[DH-384] update datahub image tag to 32dc6f548a15

### DIFF
--- a/deployments/datahub/hubploy.yaml
+++ b/deployments/datahub/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:34f4eb103e6a
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:32dc6f548a15
 
 cluster:
   provider: gcloud

--- a/deployments/dlab/hubploy.yaml
+++ b/deployments/dlab/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:34f4eb103e6a
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:32dc6f548a15
       path: ../datahub/images/default
 
 cluster:

--- a/deployments/highschool/hubploy.yaml
+++ b/deployments/highschool/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:34f4eb103e6a
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:32dc6f548a15
       path: ../datahub/images/default
 
 cluster:

--- a/deployments/prob140/hubploy.yaml
+++ b/deployments/prob140/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:34f4eb103e6a
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:32dc6f548a15
 
 cluster:
   provider: gcloud

--- a/deployments/r/hubploy.yaml
+++ b/deployments/r/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:34f4eb103e6a
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:32dc6f548a15
 
 cluster:
   provider: gcloud

--- a/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:34f4eb103e6a
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:32dc6f548a15
 
 cluster:
   provider: gcloud

--- a/deployments/workshop/hubploy.yaml
+++ b/deployments/workshop/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:34f4eb103e6a
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/datahub-user-image:32dc6f548a15
 
 cluster:
   provider: gcloud


### PR DESCRIPTION
update datahub image tag to 32dc6f548a15

deployments/datahub/hubploy.yaml
deployments/dlab/hubploy.yaml
deployments/highschool/hubploy.yaml
deployments/prob140/hubploy.yaml
deployments/r/hubploy.yaml
deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
deployments/workshop/hubploy.yaml