### PR TITLE
Debump MCB 201B RAM in Bio Hub!

### DIFF
--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -62,10 +62,6 @@ jupyterhub:
         mem_limit: 4096M
         mem_guarantee: 4096M
 
-#      course::1537301: # MCELLBI 201B, https://github.com/berkeley-dsep-infra/datahub/issues/6385
-#        mem_limit: 5120M
-#        mem_guarantee: 5120M
-
       course::1536425: # IB 134L, https://github.com/berkeley-dsep-infra/datahub/issues/6481
         mem_limit: 8192M
         mem_guarantee: 8192M

--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -61,10 +61,14 @@ jupyterhub:
       course::1524699::group::all-admins:
         mem_limit: 4096M
         mem_guarantee: 4096M
-      course::1537301: # MCELLBI 201B, https://github.com/berkeley-dsep-infra/datahub/issues/6385
-        mem_limit: 5120M
-        mem_guarantee: 5120M
 
+#      course::1537301: # MCELLBI 201B, https://github.com/berkeley-dsep-infra/datahub/issues/6385
+#        mem_limit: 5120M
+#        mem_guarantee: 5120M
+
+      course::1536425: # IB 134L, https://github.com/berkeley-dsep-infra/datahub/issues/6481
+        mem_limit: 8192M
+        mem_guarantee: 8192M
 
       # BioE C149, Fall 2024, https://github.com/berkeley-dsep-infra/datahub/issues/6205
       course::1537116::enrollment_type::teacher:


### PR DESCRIPTION
As part of https://github.com/berkeley-dsep-infra/datahub/issues/6385#issuecomment-2450840390, Instructor requested that the RAM increase be kept as-is till Nov 15th. Hence, debumping the RAM now.