### PR TITLE
[DH-435] fixing empty stanza and adding datahub staff as admins

### DIFF
--- a/deployments/astro/config/common.yaml
+++ b/deployments/astro/config/common.yaml
@@ -91,6 +91,12 @@ jupyterhub:
   # formerly jupyterhub.hub.extraConfigMap
   custom:
     group_profiles:
+      # DataHub Infrastructure staff
+      # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
+      course::1524699::group::all-admins:
+        admin: true
+        mem_limit: 4G
+
     admin:
       extraVolumeMounts:
         - name: home

--- a/deployments/astro/config/common.yaml
+++ b/deployments/astro/config/common.yaml
@@ -94,7 +94,6 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
         mem_limit: 4G
 
     admin:


### PR DESCRIPTION
i tested this by manually deploying to astro-staging.datahub.berkeley.edu