### PR TITLE
Fold admin into custom group profile.

### DIFF
--- a/deployments/a11y/config/common.yaml
+++ b/deployments/a11y/config/common.yaml
@@ -51,12 +51,10 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
-    admin:
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/shared-readwrite
-          subPath: _shared
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared
 
   singleuser:
     extraFiles:

--- a/deployments/astro/config/common.yaml
+++ b/deployments/astro/config/common.yaml
@@ -95,9 +95,7 @@ jupyterhub:
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
         mem_limit: 4G
-
-    admin:
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/shared-readwrite
-          subPath: _shared
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared

--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -50,17 +50,16 @@ jupyterhub:
         groups:
           - course::1524699::group::biology-admins
   custom:
-    admin:
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/shared-readwrite
-          subPath: _shared
     group_profiles:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
         mem_limit: 4096M
         mem_guarantee: 4096M
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared
 
   singleuser:
     extraEnv:

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -98,14 +98,11 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
         mem_limit: 4G
-
-    admin:
-      mem_guarantee: 2G
-      extraVolumeMounts:
-        - name: home
-          mountPath: /srv/homes
-        - name: home
-          mountPath: /home/jovyan/shared-readwrite
-          subPath: _shared
+        mem_guarantee: 2G
+        extraVolumeMounts:
+          - name: home
+            mountPath: /srv/homes
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared

--- a/deployments/data101/config/common.yaml
+++ b/deployments/data101/config/common.yaml
@@ -227,7 +227,5 @@ jupyterhub:
   # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
-    admin:
-      mem_limit: 4G
-      mem_guarantee: 2G
+        mem_limit: 4G
+        mem_guarantee: 2G

--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -9,11 +9,9 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
-    admin:
-      extraVolumeMounts:
-        - name: home
-          mountPath: /srv/homes
+        extraVolumeMounts:
+          - name: home
+            mountPath: /srv/homes
 
   scheduling:
     userScheduler:

--- a/deployments/dev/config/common.yaml
+++ b/deployments/dev/config/common.yaml
@@ -117,11 +117,9 @@ jupyterhub:
   #
   #    # Some other class 200, Spring '23; requested in #98776
   #    course::234567::enrollment_type::teacher:
-  #      admin: true
   #      mem_limit: 2096M
   #      mem_guarantee: 2048M
   #    course::234567::enrollment_type::ta:
-  #      admin: true
   #      mem_limit: 2096M
   #      mem_guarantee: 2048M
 

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -99,4 +99,5 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
+        mem_limit: 2G
+        mem_guarantee: 2G

--- a/deployments/publichealth/config/common.yaml
+++ b/deployments/publichealth/config/common.yaml
@@ -113,4 +113,5 @@ jupyterhub:
     group_profiles:
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
+        mem_limit: 2G
+        mem_guarantee: 2G

--- a/deployments/stat159/config/common.yaml
+++ b/deployments/stat159/config/common.yaml
@@ -124,9 +124,7 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
-    admin:
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/shared-readwrite
-          subPath: _shared
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared

--- a/deployments/stat20/config/common.yaml
+++ b/deployments/stat20/config/common.yaml
@@ -84,7 +84,6 @@ jupyterhub:
       # DataHub Infrastructure staff
       # https://bcourses.berkeley.edu/courses/1524699/groups#tab-80607
       course::1524699::group::all-admins:
-        admin: true
         mem_limit: 12G
       # Shared directory to read logs data from every semester
         extraVolumeMounts:


### PR DESCRIPTION
Instead of assigning attributes to admins, we assign them to people in the group course::1524699::group::all-admins. We also remove admin from people in that group because elevated privileges have already been assigned via loadRoles.