### PR TITLE
Install gitconfig where conda's git reads it.

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -118,7 +118,7 @@ jupyterhub:
             secretName: user-etc-gitconfig
       extraVolumeMounts:
         - name: etc-gitconfig
-          mountPath: /etc/gitconfig
+          mountPath: /srv/conda/etc/gitconfig
           subPath: gitconfig
           readOnly: true
         - name: etc-gitconfig

--- a/deployments/publichealth/config/common.yaml
+++ b/deployments/publichealth/config/common.yaml
@@ -98,7 +98,7 @@ jupyterhub:
             secretName: user-etc-gitconfig
       extraVolumeMounts:
         - name: etc-gitconfig
-          mountPath: /etc/gitconfig
+          mountPath: /srv/conda/etc/gitconfig
           subPath: gitconfig
           readOnly: true
         - name: etc-gitconfig

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -70,7 +70,7 @@ jupyterhub:
             secretName: user-etc-gitconfig
       extraVolumeMounts:
         - name: etc-gitconfig
-          mountPath: /etc/gitconfig
+          mountPath: /srv/conda/etc/gitconfig
           subPath: gitconfig
           readOnly: true
         - name: etc-gitconfig


### PR DESCRIPTION
This enables git credential helper to work.