### PR TITLE
Bump start timeout on CDSS hub.

### DIFF
--- a/deployments/cdss-discovery/config/common.yaml
+++ b/deployments/cdss-discovery/config/common.yaml
@@ -171,7 +171,7 @@ jupyterhub:
         storageAccessModes: [ReadWriteOnce]
     # /Nautilus-specific configuration
 
-    startTimeout: 900
+    startTimeout: 3600
 
     # Policy on interactive limits
     # https://docs.nationalresearchplatform.org/userdocs/start/policies/#interactive-use-vs-batch

--- a/deployments/cdss-discovery/config/common.yaml
+++ b/deployments/cdss-discovery/config/common.yaml
@@ -203,7 +203,7 @@ jupyterhub:
         image: gitlab-registry.nrp-nautilus.io/berkeley-cdss/cdss-discovery-cpu-user-image:e5750bf2
       profile_options:
         mem_limit:
-          display_name: "RAM Limit"
+          display_name: "CPU RAM Limit"
           choices:
             mem_10g:
               default: true
@@ -234,7 +234,7 @@ jupyterhub:
         image: gitlab-registry.nrp-nautilus.io/berkeley-cdss/cdss-discovery-user-image:476b008f
       profile_options:
         mem_limit:
-          display_name: "RAM Limit"
+          display_name: "CPU RAM Limit"
           choices:
             mem_10g:
               default: true


### PR DESCRIPTION
Servers still time out after 15 minutes! Let's try for 1h as @cboettig does on his hub. Also clarify that RAM is for the CPU and not GPU per @paciorek's suggestion.