### PR TITLE
Increase RAM to 16 GB for PS231D

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -199,3 +199,8 @@ jupyterhub:
       course::1542364:
         mem_limit: 4096M
         mem_guarantee: 4096M
+
+      # PS 231D, Spring 25, https://github.com/berkeley-dsep-infra/datahub/issues/6875, To be removed by end of March
+      course::1542527:
+        mem_limit: 16384M
+        mem_guarantee: 16384M


### PR DESCRIPTION
Addresses https://github.com/berkeley-dsep-infra/datahub/issues/6875

This change will be revoked by Mar 27th and it supports 5 students + instructor enrolled in PS 231D.