### PR TITLE
fix deprecation warning for ingress class

### DIFF
--- a/deployments/cdss-discovery/config/common.yaml
+++ b/deployments/cdss-discovery/config/common.yaml
@@ -95,8 +95,8 @@ jupyterhub:
   # Nautilus uses haproxy for ingress
   ingress:
     enabled: true
+    ingressClassName: haproxy
     annotations:
-      kubernetes.io/ingress.class: haproxy
       cert-manager.io/issuer: letsencrypt
       cert-manager.io/cluster-issuer: null
     pathSuffix: ''

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -8,9 +8,9 @@ jupyterhub:
     hook:
       pullOnlyOnChanges: true
   ingress:
+    ingressClassName: nginx
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 256m
-      kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: letsencrypt-prod
       acme.cert-manager.io/http01-edit-in-place: "true"
   scheduling:

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -125,6 +125,7 @@ grafana:
 
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       # Increase timeout for each query made by the grafana frontend to the
       # grafana backend to 2min, which is the default timeout for prometheus
@@ -133,7 +134,6 @@ grafana:
       # to allow prometheus the best chance of executing queries we care about.
       # See: https://github.com/2i2c-org/infrastructure/pull/2942
       nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
-      kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: letsencrypt-prod
     hosts:
       - grafana.datahub.berkeley.edu


### PR DESCRIPTION
i tested this by manually deploying to `logodev` w/o issue.

i have the exact same configs in the cal-icor repo:  https://github.com/cal-icor/cal-icor-hubs/pull/103