### PR TITLE
[DH-501] Increase resources in prep for demog workshop and ischool classes next week

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -59,5 +59,5 @@ jupyterhub:
         subPath: "{username}"
     memory:
       # As low a guarantee as possible
-      guarantee: 1G
-      limit: 1G
+      guarantee: 4G
+      limit: 4G

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -167,7 +167,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   julia:
     nodeSelector:
       hub.jupyter.org/pool-name: julia-pool
@@ -223,4 +223,4 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1


### PR DESCRIPTION
1. Increases RAM to 4 GB for workshop hub (https://github.com/berkeley-dsep-infra/datahub/issues/7055)
2. Sets node placeholder to 1 for small-courses nodepool and ischool nodepool