### PR TITLE
Debump workshop hub's memory guarantee and limit to 512 MB

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -59,5 +59,5 @@ jupyterhub:
         subPath: "{username}"
     memory:
       # As low a guarantee as possible
-      guarantee: 1G
-      limit: 1G
+      guarantee: 512M
+      limit: 512M


### PR DESCRIPTION
To test auto scaler workflow