### PR TITLE
[DH-73] Allow Data8 Hub access to users enrolled in bcourses roster from Spring 25 and Summer 25

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -45,8 +45,9 @@ jupyterhub:
           # https://bcourses.berkeley.edu/courses/1542000
           - "course::1542000"
           # Data 8, 2025 Summer
+          - "course::1544818"
           # https://bcourses.berkeley.edu/courses/1544818
-          # DataHub staff
+          # DataHub staff (Commented for testing purposes)
           #- "course::1524699::group::all-admins"
     loadRoles:
       # datahub staff

--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -38,6 +38,16 @@ jupyterhub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2024-05-08
     config:
+      OAuthenticator:
+        allow_all: False
+        allowed_groups:
+          # Data 8, 2025 Spring
+          # https://bcourses.berkeley.edu/courses/1542000
+          - "course::1542000"
+          # Data 8, 2025 Summer
+          # https://bcourses.berkeley.edu/courses/1544818
+          # DataHub staff
+          #- "course::1524699::group::all-admins"
     loadRoles:
       # datahub staff
       datahub-staff:


### PR DESCRIPTION
- Allows students enrolled in data8's bcourses roster for Spring and Summer 25 to access the Data8 hub
- Commented out DataHub admins group for testing purposes. Will uncomment the stanza once we verify that the config is working as expected.