### PR TITLE
update the patience message during spawn delay to include the timeout

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -350,7 +350,7 @@ jupyterhub:
 
           spawn_launcher_timer_message = Unicode(
             """
-            Server launch is taking longer than expected. Please be patient!
+            Server launch is taking longer than expected. Please be patient, the timeout is 300 seconds.
             """,
             config=True,
             help="""


### PR DESCRIPTION
i added this helpful message to the cal-icor hubs (https://github.com/cal-icor/cal-icor-hubs/blob/staging/hub/values.yaml#L432), so i figured i'd put it in here as well.  :)

this is a super minor change, and is safe to merge.