### PR TITLE
Temporarily disable cdss-discovery.

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -173,7 +173,7 @@ jobs:
             echo "Deploying single-user image and hub config to ${deployment}"
             hubploy --verbose deploy --timeout 30m ${deployment} hub staging
             echo
-          done < <(python .github/scripts/determine-hub-deployments.py)
+          done < <(python .github/scripts/determine-hub-deployments.py --ignore cdss-discovery)
 
   deploy-hubs-to-prod:
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'


### PR DESCRIPTION
Something in CI is causing cdss-discovery to be read as discovery. (possibly `determine-hub-deployments.py`?) I'm disabling the deployment until I've time to look into it.