### PR TITLE
[Edx] Updates to image

### DIFF
--- a/deployments/edx/config/staging.yaml
+++ b/deployments/edx/config/staging.yaml
@@ -17,4 +17,4 @@ jupyterhub:
         url: http://grader-srv-staging.datahub.berkeley.edu:10101
     image:
       name: us-central1-docker.pkg.dev/data8x-scratch/core/hub
-      tag: '90bb3bf0'
+      tag: 'edx_prod_working'


### PR DESCRIPTION
- hub image is set to LTI 1.1 old image because we are not ready for LTI 1.3
- user image updated with yfinance