### PR TITLE
Use `unescaped_username` template var.

### DIFF
--- a/deployments/stat159/config/common.yaml
+++ b/deployments/stat159/config/common.yaml
@@ -87,17 +87,14 @@ jupyterhub:
       # Unset NotebookApp from hub/values. Necessary for recent lab versions.
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
       JUPYTER_PATH: "/srv/conda/envs/shared/share/jupyter"
+      # For myst development
+      BASE_URL: "/user/{unescaped_username}/proxy/8000"
     #cmd:
     #  - jupyterhub-singleuser
     #  - --LabApp.collaborative=true
     #  # https://jupyterlab-realtime-collaboration.readthedocs.io/en/latest/configuration.html#configuration
     #  - --YDocExtension.ystore_class=tmpystore.TmpYStore
     extraFiles:
-      base-url:
-        mountPath: /etc/profile.d/00-base-url.sh
-        stringData: |
-          #!/bin/bash
-          export BASE_URL="/user/${JUPYTERHUB_USER}/proxy/8000"
       # DH-216
       remove-exporters:
         mountPath: /etc/jupyter/jupyter_notebook_config.py


### PR DESCRIPTION
Setting the env var via bash file worked, but this method is better.