### PR TITLE
Enable persistent conda envs.

### DIFF
--- a/deployments/stat159/config/common.yaml
+++ b/deployments/stat159/config/common.yaml
@@ -87,6 +87,13 @@ jupyterhub:
       # Unset NotebookApp from hub/values. Necessary for recent lab versions.
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
       JUPYTER_PATH: "/srv/conda/envs/shared/share/jupyter"
+      # Fernando wants students to have persistent envs, but it is hard
+      # to get each student to write out a ~/.condarc. We set envs instead.
+      # https://github.com/berkeley-dsep-infra/stat159-user-image/issues/28
+      CONDA_ENVS_PATH: "/home/jovyan/.local/share/envs:/srv/conda/envs"
+      # Without the setting below, pkgs would persist in home directories.
+      # https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/settings.html#pkgs-dirs-specify-package-directories
+      CONDA_PKGS_DIRS: "/srv/conda/pkgs"
       # For myst development
       #BASE_URL: "/user/{unescaped_username}/proxy/8000"
     #cmd:


### PR DESCRIPTION
Setting env vars means that students don't need to write out their own ~/.condarc as course staff would previously instruct. We also set the package cache to be in ephemeral docker storage.

As requested in https://github.com/berkeley-dsep-infra/stat159-user-image/issues/28.