### PR TITLE
Set windowing mode to `defer` in Data8 hub

### DIFF
--- a/deployments/data8/config/common.yaml
+++ b/deployments/data8/config/common.yaml
@@ -113,6 +113,15 @@ jupyterhub:
 
   singleuser:
     extraFiles:
+      # DH-596
+      jupyter-lab-overrides:
+        mountPath:  /srv/conda/share/jupyter/lab/settings/overrides.json
+        stringData:  |
+          {
+            "@jupyterlab/notebook-extension:tracker": {
+              "windowingMode": "defer"
+            }
+          }
       # DH-305
       remove-exporters:
         mountPath: /etc/jupyter/jupyter_notebook_config.py


### PR DESCRIPTION
Ref: https://github.com/berkeley-dsep-infra/datahub/pull/7434/files

@felder fixed a similar scrolling issue reported by instructors using R and Data100 hubs at the start of FA 25.