### PR TITLE
Set bio, data100 and eecs node placeholder values to 1

### DIFF
--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -87,7 +87,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   cee:
     nodeSelector:
       hub.jupyter.org/pool-name: cee-pool
@@ -103,7 +103,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 207314055168
-    replicas: 0
+    replicas: 1
   data101:
     nodeSelector:
       hub.jupyter.org/pool-name: data101-pool
@@ -159,7 +159,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 0
+    replicas: 1
   ischool:
     nodeSelector:
       hub.jupyter.org/pool-name: ischool-pool


### PR DESCRIPTION
To support a) Biology and data100 users who want to back up their files, and b) the EECS course that has an assignment released during winter break