### PR TITLE
Revert to previous image tag in Data100 hub

### DIFF
--- a/deployments/data100/hubploy.yaml
+++ b/deployments/data100/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/data100-user-image:0880553a61a1
+    - name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/data100-user-image:818aefa4cf32
 
 cluster:
   provider: gcloud


### PR DESCRIPTION
To fix the issue reported in this GitHub issue: https://github.com/berkeley-dsep-infra/datahub/issues/7857#issuecomment-3762642532

Hubployed the previous image tag of Data100 during Friday night. Merging this change via PR so that other changes don't revert the hubploy fix.