### PR TITLE
Spin down resources for Nature hub

### DIFF
--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -183,7 +183,7 @@ nodePools:
       requests:
         # Some value slightly lower than allocatable RAM on the nodepool
         memory: 60929654784
-    replicas: 1
+    replicas: 0
   prob140:
     nodeSelector:
       hub.jupyter.org/pool-name: prob140-pool


### PR DESCRIPTION
@cboettig is experimenting with a) JupyterHub on NRP and b) students locally installing VSCode to support his instruction for some period of time. As a result, spinning down the resources on Nature Hub.