### PR TITLE
Fix mount paths in common.yaml for git credentials

### DIFF
--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -80,13 +80,13 @@ jupyterhub:
           c.QtPNGExporter.enabled = False
           c.WebPDFExporter.embed_images = True
       git-credential-helper:
-        mountPath: /srv/conda/env/notebooks/etc/gitconfig
+        mountPath: /srv/conda/envs/notebook/etc/gitconfig
         stringData: |
           [credential "https://github.com"]
-            helper = !git-credential-github-app --app-key-file /srv/conda/env/notebooks/etc/github/github-app-private-key.pem --app-id 229235
+            helper = !git-credential-github-app --app-key-file /srv/conda/envs/notebook/etc/github/github-app-private-key.pem --app-id 229235
             useHttpPath = true
       git-credential-helper-private-key:
-        mountPath: /srv/conda/env/notebooks/etc/github/github-app-private-key.pem
+        mountPath: /srv/conda/envs/notebook/etc/github/github-app-private-key.pem
         # data in secret file
 
     nodeSelector:


### PR DESCRIPTION
Updated mount paths for git-credential-helper and private key.