### PR TITLE
Update DataHub memory limit in prod.yaml

### DIFF
--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -25,7 +25,7 @@ jupyterhub:
         cpu: 1
         memory: 1Gi
       limits:
-        memory: 2Gi
+        memory: 4Gi
 
   scheduling:
     userPlaceholder:


### PR DESCRIPTION
Increase memory limit for DataHub from 2Gi to 4Gi.