### PR TITLE
Debump RAM in workshop hub

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -66,5 +66,5 @@ jupyterhub:
         subPath: "{username}"
     memory:
       # As low a guarantee as possible
-      guarantee: 4G
-      limit: 4G
+      guarantee: 512M
+      limit: 512M


### PR DESCRIPTION
The Demography department workshop ended yesterday (https://github.com/berkeley-dsep-infra/datahub/issues/8201), so we can debump the 4 GB RAM allocated to the workshop hub.